### PR TITLE
Gmail for work addresses generates undefined method `to_sym' for nil:NilClass

### DIFF
--- a/lib/email_address/host.rb
+++ b/lib/email_address/host.rb
@@ -291,7 +291,7 @@ module EmailAddress
 
     # True if the :dns_lookup setting is enabled
     def dns_enabled?
-      EmailAddress::Config.setting(:dns_lookup)
+      EmailAddress::Config.setting(:dns_lookup).equal?(:off) ? false : true
     end
 
     # True if the host name has a DNS A Record

--- a/lib/email_address/host.rb
+++ b/lib/email_address/host.rb
@@ -182,7 +182,7 @@ module EmailAddress
       provider = self.exchangers.provider
       if provider != :default
         self.set_provider(provider,
-          EmailAddress::Config.provider(self.provider))
+          EmailAddress::Config.provider(provider))
       end
 
       self.provider ||= self.set_provider(:default)

--- a/test/email_address/test_host.rb
+++ b/test/email_address/test_host.rb
@@ -12,6 +12,15 @@ class TestHost < MiniTest::Test
     assert_equal "ex*****", a.munge
     assert_equal nil, a.subdomains
   end
+  
+  def test_dns_enabled
+    a = EmailAddress::Host.new("example.com")
+    assert_instance_of TrueClass, a.dns_enabled?
+    old_setting = EmailAddress::Config.setting(:dns_lookup)
+    EmailAddress::Config.configure(dns_lookup: :off)
+    assert_instance_of FalseClass, a.dns_enabled?
+    EmailAddress::Config.configure(dns_lookup: old_setting)
+  end
 
   def test_foreign_host
     a = EmailAddress::Host.new("my.yahoo.co.jp")


### PR DESCRIPTION
Trying to pass in a Gmail for work address to some methods (e.g. `EmailAddress.canonical(..)`) for me generate the following error:

```
/usr/local/rvm/gems/ruby-2.2.1/gems/email_address-0.1.0/lib/email_address/config.rb:153:in `provider': undefined method `to_sym' for nil:NilClass (NoMethodError)
        from /usr/local/rvm/gems/ruby-2.2.1/gems/email_address-0.1.0/lib/email_address/host.rb:185:in `find_provider'
        from /usr/local/rvm/gems/ruby-2.2.1/gems/email_address-0.1.0/lib/email_address/host.rb:167:in `host_name='
        from /usr/local/rvm/gems/ruby-2.2.1/gems/email_address-0.1.0/lib/email_address/host.rb:130:in `parse'
        from /usr/local/rvm/gems/ruby-2.2.1/gems/email_address-0.1.0/lib/email_address/host.rb:89:in `initialize'
        from /usr/local/rvm/gems/ruby-2.2.1/gems/email_address-0.1.0/lib/email_address/address.rb:28:in `new'
        from /usr/local/rvm/gems/ruby-2.2.1/gems/email_address-0.1.0/lib/email_address/address.rb:28:in `initialize'
        from /usr/local/rvm/gems/ruby-2.2.1/gems/email_address-0.1.0/lib/email_address.rb:19:in `new'
        from /usr/local/rvm/gems/ruby-2.2.1/gems/email_address-0.1.0/lib/email_address.rb:19:in `new'
        from -e:1:in `<main>'
```

To quickly reproduce, run `ruby -remail_address 'puts EmailAddress.canonical(user@gmailforworkemail.com)'` where user@gmailforworkemail.com is an actual Gmail for work email. I didn't want to drop my work email on here, so let me know if you need an actual example to test against. ;)

Seems the culprit is passing `self.provider` to `EmailAddress::Config.provider`. Passing `provider` instead seems to do the trick; here's a PR that does that!