### PR TITLE
Shorten EmailAddress using define_method

### DIFF
--- a/lib/email_address.rb
+++ b/lib/email_address.rb
@@ -13,57 +13,22 @@ module EmailAddress
     require "email_address/canonical_email_address_type"
   end
 
+  def self.method_missing(m, *args, &block)
+    EmailAddress::Address.new(*args, &block).send(m)
+  end
+
   # Creates an instance of this email address.
   # This is a short-cut to Email::Address::Address.new
   def self.new(email_address, config={})
     EmailAddress::Address.new(email_address, config)
   end
 
-  # Given an email address, this returns true if the email validates, false otherwise
-  def self.valid?(email_address, config={})
-    self.new(email_address, config).valid?
-  end
-
-  # Given an email address, this returns nil if the email validates,
-  # or a string with a small error message otherwise
-  def self.error(email_address, config={})
-    self.new(email_address, config).error
-  end
-
-  # Shortcut to normalize the given email address in the given format
-  def self.normal(email_address, config={})
-    EmailAddress::Address.new(email_address, config).to_s
-  end
-
-  # Shortcut to normalize the given email address
-  def self.redact(email_address, config={})
-    EmailAddress::Address.new(email_address, config).redact
-  end
-
-  # Shortcut to munge the given email address for web publishing
-  # returns ma_____@do_____.com
-  def self.munge(email_address, config={})
-    EmailAddress::Address.new(email_address, config).munge
-  end
-
   def self.new_redacted(email_address, config={})
     EmailAddress::Address.new(EmailAddress::Address.new(email_address, config).redact)
   end
 
-  # Returns the Canonical form of the email address. This form is what should
-  # be considered unique for an email account, lower case, and no address tags.
-  def self.canonical(email_address, config={})
-    EmailAddress::Address.new(email_address, config).canonical
-  end
-
   def self.new_canonical(email_address, config={})
     EmailAddress::Address.new(EmailAddress::Address.new(email_address, config).canonical, config)
-  end
-
-  # Returns the Reference form of the email address, defined as the MD5
-  # digest of the Canonical form.
-  def self.reference(email_address, config={})
-    EmailAddress::Address.new(email_address, config).reference
   end
 
   # Does the email address match any of the given rules

--- a/lib/email_address.rb
+++ b/lib/email_address.rb
@@ -23,6 +23,21 @@ module EmailAddress
     end
   end
 
+  # @method self.valid?(options={})
+  #   Proxy method to {EmailAddress::Address#valid?}
+  # @method self.error
+  #   Proxy method to {EmailAddress::Address#error}
+  # @method self.normal
+  #   Proxy method to {EmailAddress::Address#normal}
+  # @method self.redact(digest=:sha1)
+  #   Proxy method to {EmailAddress::Address#redact}
+  # @method self.munge
+  #   Proxy method to {EmailAddress::Address#munge}
+  # @method self.canonical
+  #   Proxy method to {EmailAddress::Address#canonical}
+  # @method self.reference
+  #   Proxy method to {EmailAddress::Address#reference}
+
   # Creates an instance of this email address.
   # This is a short-cut to Email::Address::Address.new
   def self.new(email_address, config={})

--- a/lib/email_address.rb
+++ b/lib/email_address.rb
@@ -14,10 +14,12 @@ module EmailAddress
   end
 
   class << self
-    %i(valid? error normal redact munge canonical reference).each do |proxy_method|
+    (%i[valid? error normal redact munge canonical reference] &
+     EmailAddress::Address.public_instance_methods
+    ).each do |proxy_method|
       define_method(proxy_method) do |*args, &block|
-        EmailAddress::Address.new(*args).send(proxy_method, &block)
-      end if EmailAddress::Address.method_defined? proxy_method
+        EmailAddress::Address.new(*args).public_send(proxy_method, &block)
+      end
     end
   end
 

--- a/lib/email_address.rb
+++ b/lib/email_address.rb
@@ -17,7 +17,7 @@ module EmailAddress
     %i(valid? error normal redact munge canonical reference).each do |proxy_method|
       define_method(proxy_method) do |*args, &block|
         EmailAddress::Address.new(*args).send(proxy_method, &block)
-      end
+      end if EmailAddress::Address.method_defined? proxy_method
     end
   end
 

--- a/lib/email_address.rb
+++ b/lib/email_address.rb
@@ -13,6 +13,20 @@ module EmailAddress
     require "email_address/canonical_email_address_type"
   end
 
+  # @!method self.valid?(options={})
+  #   Proxy method to {EmailAddress::Address#valid?}
+  # @!method self.error
+  #   Proxy method to {EmailAddress::Address#error}
+  # @!method self.normal
+  #   Proxy method to {EmailAddress::Address#normal}
+  # @!method self.redact(digest=:sha1)
+  #   Proxy method to {EmailAddress::Address#redact}
+  # @!method self.munge
+  #   Proxy method to {EmailAddress::Address#munge}
+  # @!method self.canonical
+  #   Proxy method to {EmailAddress::Address#canonical}
+  # @!method self.reference
+  #   Proxy method to {EmailAddress::Address#reference}
   class << self
     (%i[valid? error normal redact munge canonical reference] &
      EmailAddress::Address.public_instance_methods
@@ -23,20 +37,6 @@ module EmailAddress
     end
   end
 
-  # @method self.valid?(options={})
-  #   Proxy method to {EmailAddress::Address#valid?}
-  # @method self.error
-  #   Proxy method to {EmailAddress::Address#error}
-  # @method self.normal
-  #   Proxy method to {EmailAddress::Address#normal}
-  # @method self.redact(digest=:sha1)
-  #   Proxy method to {EmailAddress::Address#redact}
-  # @method self.munge
-  #   Proxy method to {EmailAddress::Address#munge}
-  # @method self.canonical
-  #   Proxy method to {EmailAddress::Address#canonical}
-  # @method self.reference
-  #   Proxy method to {EmailAddress::Address#reference}
 
   # Creates an instance of this email address.
   # This is a short-cut to Email::Address::Address.new

--- a/lib/email_address.rb
+++ b/lib/email_address.rb
@@ -13,8 +13,12 @@ module EmailAddress
     require "email_address/canonical_email_address_type"
   end
 
-  def self.method_missing(m, *args, &block)
-    EmailAddress::Address.new(*args, &block).send(m)
+  class << self
+    %i(valid? error normal redact munge canonical reference).each do |proxy_method|
+      define_method(proxy_method) do |*args, &block|
+        EmailAddress::Address.new(*args).send(proxy_method, &block)
+      end
+    end
   end
 
   # Creates an instance of this email address.


### PR DESCRIPTION
I suggest we use `method_missing` to have a shorter `EmailAddress` class.