### PR TITLE
Update `NetAddr` dependency to version 2.0

### DIFF
--- a/email_address.gemspec
+++ b/email_address.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "codeclimate-test-reporter"
 
   spec.add_dependency "simpleidn"
-  spec.add_dependency "netaddr", "~> 1.5.1"
+  spec.add_dependency "netaddr", "~> 2.0"
 end

--- a/lib/email_address/host.rb
+++ b/lib/email_address/host.rb
@@ -455,11 +455,17 @@ module EmailAddress
 
     def localhost?
       if self.ip_address
-        if self.ip_address.include?(":")
-          return NetAddr::CIDR.create("::1").matches?(self.ip_address)
-        else
-          return NetAddr::CIDR.create("127.0.0.0/8").matches?(self.ip_address)
-        end
+        rel =
+          if self.ip_address.include?(":")
+            NetAddr::IPv6Net.parse("::1").rel(
+              NetAddr::IPv6Net.parse(self.ip_address)
+            )
+          else
+            NetAddr::IPv4Net.parse("127.0.0.0/8").rel(
+              NetAddr::IPv4Net.parse(self.ip_address)
+            )
+          end
+        !rel.nil? && rel >= 0
       else
         self.host_name == 'localhost'
       end


### PR DESCRIPTION
[`NetAddr::CIDR`](http://www.rubydoc.info/gems/netaddr/1.5.0/NetAddr/CIDR) was removed, I replaced it with [`NetAddr::IPv4Net`](http://www.rubydoc.info/gems/netaddr/NetAddr/IPv4Net) and [`IPv6Net`](http://www.rubydoc.info/gems/netaddr/NetAddr/IPv6Net) separately.

[`NetAddr::CIDR#matches?`](http://www.rubydoc.info/gems/netaddr/1.5.0/NetAddr/CIDR#matches%3F-instance_method) replaced with [`NetAddr::IPv4Net#rel`](http://www.rubydoc.info/gems/netaddr/NetAddr/IPv4Net#rel-instance_method) and [`NetAddr::IPv6Net#rel`](http://www.rubydoc.info/gems/netaddr/NetAddr/IPv6Net#rel-instance_method).

Completely resolves #19.

Any suggestions about the code?