### PR TITLE
fix local.to_s returning nil if relaxed is specified

### DIFF
--- a/lib/email_address/local.rb
+++ b/lib/email_address/local.rb
@@ -189,7 +189,7 @@ module EmailAddress
         self.conventional
       elsif form == :canonical
         self.canonical
-      elsif form == :relax
+      elsif form == :relaxed
         self.relax
       elsif form == :standard
         self.standard

--- a/test/email_address/test_address.rb
+++ b/test/email_address/test_address.rb
@@ -112,4 +112,8 @@ class TestAddress < Minitest::Test
     assert ! EmailAddress.valid?('example.user@foo.com/')
   end
 
+  def test_relaxed_normal
+    assert ! EmailAddress.new('a.c.m.e.-industries@foo.com').valid?
+    assert true, EmailAddress.new('a.c.m.e.-industries@foo.com', local_format: :relaxed).valid?
+  end
 end


### PR DESCRIPTION
When `local_format: :relaxed` is specified, `EmailAddress::Local#format` would return nil because
it is looking for the key `:relax`, but it is specified as `:relaxed` everywhere else. This change
corrects the key used for comparison.