### PR TITLE
Add config option to set a DNS lookup timeout

### DIFF
--- a/lib/email_address/config.rb
+++ b/lib/email_address/config.rb
@@ -9,6 +9,9 @@ module EmailAddress
   #   :a        - DNS A Record lookup (as some domains don't specify an MX incorrectly)
   #   :off      - Do not perform DNS lookup (Test mode, network unavailable)
   #
+  # * dns_timeout:        nil
+  #   False, or a timeout in seconds. Timeout on the DNS lookup, after which it will fail.
+  #
   # * sha1_secret         ""
   #   This application-level secret is appended to the email_address to compute
   #   the SHA1 Digest, making it unique to your application so it can't easily be
@@ -99,6 +102,7 @@ module EmailAddress
   class Config
     @config = {
       dns_lookup:         :mx,  # :mx, :a, :off
+      dns_timeout:        nil,
       sha1_secret:        "",
       munge_string:       "*****",
 

--- a/lib/email_address/exchanger.rb
+++ b/lib/email_address/exchanger.rb
@@ -52,7 +52,14 @@ module EmailAddress
     def mxers
       return [["example.com", "0.0.0.0", 1]] if @config[:dns_lookup] == :off
       @mxers ||= Resolv::DNS.open do |dns|
-        ress = dns.getresources(@host, Resolv::DNS::Resource::IN::MX)
+        dns.timeouts = @config[:dns_timeout] if @config[:dns_timeout]
+
+        ress = begin
+          dns.getresources(@host, Resolv::DNS::Resource::IN::MX)
+        rescue Resolv::ResolvTimeout
+          []
+        end
+
         records = ress.map do |r|
           begin
             if r.exchange.to_s > " "

--- a/lib/email_address/host.rb
+++ b/lib/email_address/host.rb
@@ -426,7 +426,7 @@ module EmailAddress
         else
           true
         end
-      elsif valid_dns?
+      elsif @config[:dns_timeout].nil? && valid_dns?
         set_error(:domain_does_not_accept_email)
       else
         set_error(:domain_unknown)

--- a/lib/email_address/host.rb
+++ b/lib/email_address/host.rb
@@ -352,8 +352,14 @@ module EmailAddress
     # Returns a DNS TXT Record
     def txt(alternate_host=nil)
       Resolv::DNS.open do |dns|
-        records = dns.getresources(alternate_host || self.dns_name,
+        dns.timeouts = @config[:dns_timeout] if @config[:dns_timeout]
+        records = begin
+          dns.getresources(alternate_host || self.dns_name,
                          Resolv::DNS::Resource::IN::TXT)
+        rescue Resolv::ResolvTimeout
+          []
+        end
+
         records.empty? ? nil : records.map(&:data).join(" ")
       end
     end


### PR DESCRIPTION
We've been using this gem and getting occasional request timeouts while execution is in Resolv.

To guard against this I'd like to set a timeout on the DNS lookups.

Can you think of any nice ways to test this?