### PR TITLE
Change main namespace from EmailAddress to CheckEmailAddress

### DIFF
--- a/email_address.gemspec
+++ b/email_address.gemspec
@@ -5,10 +5,10 @@ require 'email_address/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "email_address"
-  spec.version       = EmailAddress::VERSION
+  spec.version       = CheckEmailAddress::VERSION
   spec.authors       = ["Allen Fair"]
   spec.email         = ["allen.fair@gmail.com"]
-  spec.description   = %q{The EmailAddress Gem to work with and validate email addresses.}
+  spec.description   = %q{The CheckEmailAddress Gem to work with and validate email addresses.}
   spec.summary       = %q{This gem provides a ruby language library for working with and validating email addresses. By default, it validates against conventional usage, the format preferred for user email addresses. It can be configured to validate against RFC “Standard” formats, common email service provider formats, and perform DNS validation.}
   spec.homepage      = "https://github.com/afair/email_address"
   spec.license       = "MIT"

--- a/lib/email_address.rb
+++ b/lib/email_address.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# EmailAddress parses and validates email addresses against RFC standard,
+# CheckEmailAddress parses and validates email addresses against RFC standard,
 # conventional, canonical, formats and other special uses.
-module EmailAddress
+module CheckEmailAddress
 
   require "email_address/config"
   require "email_address/exchanger"
@@ -18,20 +18,20 @@ module EmailAddress
   end
 
   # @!method self.valid?(email_address, options={})
-  #   Proxy method to {EmailAddress::Address#valid?}
+  #   Proxy method to {CheckEmailAddress::Address#valid?}
   # @!method self.error(email_address)
-  #   Proxy method to {EmailAddress::Address#error}
+  #   Proxy method to {CheckEmailAddress::Address#error}
   # @!method self.normal(email_address)
-  #   Proxy method to {EmailAddress::Address#normal}
+  #   Proxy method to {CheckEmailAddress::Address#normal}
   # @!method self.redact(email_address, options={})
-  #   Proxy method to {EmailAddress::Address#redact}
+  #   Proxy method to {CheckEmailAddress::Address#redact}
   # @!method self.munge(email_address, options={})
-  #   Proxy method to {EmailAddress::Address#munge}
+  #   Proxy method to {CheckEmailAddress::Address#munge}
   # @!method self.base(email_address, options{})
   #   Returns the base form of the email address, the mailbox
   #   without optional puncuation removed, no tag, and the host name.
   # @!method self.canonical(email_address, options{})
-  #   Proxy method to {EmailAddress::Address#canonical}
+  #   Proxy method to {CheckEmailAddress::Address#canonical}
   # @!method self.reference(email_address, form=:base, options={})
   #   Returns the reference form of the email address, by default
   #   the MD5 digest of the Base Form the the address.
@@ -40,10 +40,10 @@ module EmailAddress
   #   secret to use in options[:secret]
   class << self
     (%i[valid? error normal redact munge canonical reference base srs] &
-     EmailAddress::Address.public_instance_methods
+     CheckEmailAddress::Address.public_instance_methods
     ).each do |proxy_method|
       define_method(proxy_method) do |*args, &block|
-        EmailAddress::Address.new(*args).public_send(proxy_method, &block)
+        CheckEmailAddress::Address.new(*args).public_send(proxy_method, &block)
       end
     end
   end
@@ -52,19 +52,19 @@ module EmailAddress
   # Creates an instance of this email address.
   # This is a short-cut to Email::Address::Address.new
   def self.new(email_address, config={})
-    EmailAddress::Address.new(email_address, config)
+    CheckEmailAddress::Address.new(email_address, config)
   end
 
   def self.new_redacted(email_address, config={})
-    EmailAddress::Address.new(EmailAddress::Address.new(email_address, config).redact)
+    CheckEmailAddress::Address.new(CheckEmailAddress::Address.new(email_address, config).redact)
   end
 
   def self.new_canonical(email_address, config={})
-    EmailAddress::Address.new(EmailAddress::Address.new(email_address, config).canonical, config)
+    CheckEmailAddress::Address.new(CheckEmailAddress::Address.new(email_address, config).canonical, config)
   end
 
   # Does the email address match any of the given rules
   def self.matches?(email_address, rules, config={})
-    EmailAddress::Address.new(email_address, config).matches?(rules)
+    CheckEmailAddress::Address.new(email_address, config).matches?(rules)
   end
 end

--- a/lib/email_address/active_record_validator.rb
+++ b/lib/email_address/active_record_validator.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-module EmailAddress
+module CheckEmailAddress
 
   # ActiveRecord validator class for validating an email
   # address with this library.
   # Note the initialization happens once per process.
   #
   # Usage:
-  #    validates_with EmailAddress::ActiveRecordValidator, field: :name
+  #    validates_with CheckEmailAddress::ActiveRecordValidator, field: :name
   #
   # Options:
   # * field: email,
@@ -35,10 +35,10 @@ module EmailAddress
 
     def validate_email(r,f)
       return if r[f].nil?
-      e = EmailAddress.new(r[f])
+      e = CheckEmailAddress.new(r[f])
       unless e.valid?
         r.errors[f] << (@opt[:message] ||
-                       EmailAddress::Config.error_messages[:invalid_address] ||
+                       CheckEmailAddress::Config.error_messages[:invalid_address] ||
                        "Invalid Email Address")
       end
     end

--- a/lib/email_address/address.rb
+++ b/lib/email_address/address.rb
@@ -3,21 +3,21 @@
 require 'digest/sha1'
 require 'digest/md5'
 
-module EmailAddress
+module CheckEmailAddress
   # Implements the Email Address container, which hold the Local
-  # (EmailAddress::Local) and Host (Email::AddressHost) parts.
+  # (CheckEmailAddress::Local) and Host (Email::AddressHost) parts.
   class Address
     include Comparable
-    include EmailAddress::Rewriter
+    include CheckEmailAddress::Rewriter
 
     attr_accessor :original, :local, :host, :config, :reason
 
-    CONVENTIONAL_REGEX = /\A#{::EmailAddress::Local::CONVENTIONAL_MAILBOX_WITHIN}
-                           @#{::EmailAddress::Host::DNS_HOST_REGEX}\z/x
-    STANDARD_REGEX     = /\A#{::EmailAddress::Local::STANDARD_LOCAL_WITHIN}
-                           @#{::EmailAddress::Host::DNS_HOST_REGEX}\z/x
-    RELAXED_REGEX      = /\A#{::EmailAddress::Local::RELAXED_MAILBOX_WITHIN}
-                           @#{::EmailAddress::Host::DNS_HOST_REGEX}\z/x
+    CONVENTIONAL_REGEX = /\A#{::CheckEmailAddress::Local::CONVENTIONAL_MAILBOX_WITHIN}
+                           @#{::CheckEmailAddress::Host::DNS_HOST_REGEX}\z/x
+    STANDARD_REGEX     = /\A#{::CheckEmailAddress::Local::STANDARD_LOCAL_WITHIN}
+                           @#{::CheckEmailAddress::Host::DNS_HOST_REGEX}\z/x
+    RELAXED_REGEX      = /\A#{::CheckEmailAddress::Local::RELAXED_MAILBOX_WITHIN}
+                           @#{::CheckEmailAddress::Host::DNS_HOST_REGEX}\z/x
 
     # Given an email address of the form "local@hostname", this sets up the
     # instance, and initializes the address to the "normalized" format of the
@@ -27,11 +27,11 @@ module EmailAddress
       email_address  = (email_address || "").strip
       @original      = email_address
       email_address  = parse_rewritten(email_address) unless config[:skip_rewrite]
-      local, host    = EmailAddress::Address.split_local_host(email_address)
+      local, host    = CheckEmailAddress::Address.split_local_host(email_address)
 
-      @host         = EmailAddress::Host.new(host, config)
+      @host         = CheckEmailAddress::Host.new(host, config)
       @config       = @host.config
-      @local        = EmailAddress::Local.new(local, @config, @host)
+      @local        = CheckEmailAddress::Local.new(local, @config, @host)
       @error        = @error_message = nil
     end
 
@@ -115,7 +115,7 @@ module EmailAddress
     alias :to_s :normal
 
     def inspect
-      "#<EmailAddress::Address:0x#{self.object_id.to_s(16)} address=\"#{self.to_s}\">"
+      "#<CheckEmailAddress::Address:0x#{self.object_id.to_s(16)} address=\"#{self.to_s}\">"
     end
 
     # Returns the canonical email address according to the provider
@@ -191,7 +191,7 @@ module EmailAddress
     # of this addres with another, using the canonical or redacted forms.
     def same_as?(other_email)
       if other_email.is_a?(String)
-        other_email = EmailAddress::Address.new(other_email)
+        other_email = CheckEmailAddress::Address.new(other_email)
       end
 
       self.canonical   == other_email.canonical ||
@@ -282,7 +282,7 @@ module EmailAddress
     def set_error(err, reason=nil)
       @error = err
       @reason= reason
-      @error_message = EmailAddress::Config.error_message(err)
+      @error_message = CheckEmailAddress::Config.error_message(err)
       false
     end
 

--- a/lib/email_address/canonical_email_address_type.rb
+++ b/lib/email_address/canonical_email_address_type.rb
@@ -6,9 +6,9 @@
 # 1) Register your types
 #
 #    # config/initializers/email_address.rb
-#    ActiveRecord::Type.register(:email_address, EmailAddress::Address)
+#    ActiveRecord::Type.register(:email_address, CheckEmailAddress::Address)
 #    ActiveRecord::Type.register(:canonical_email_address,
-#                                EmailAddress::CanonicalEmailAddressType)
+#                                CheckEmailAddress::CanonicalCheckEmailAddressType)
 #
 # 2) Define your email address columns in your model class
 #
@@ -29,20 +29,20 @@
 #    user.canonical_email #=> "patsmith@gmail.com"
 ################################################################################
 
-class EmailAddress::CanonicalEmailAddressType < ActiveRecord::Type::Value
+class CheckEmailAddress::CanonicalCheckEmailAddressType < ActiveRecord::Type::Value
 
   # From user input, setter
   def cast(value)
-    super(EmailAddress.canonical(value))
+    super(CheckEmailAddress.canonical(value))
   end
 
   # From a database value
   def deserialize(value)
-    value && EmailAddress.normal(value)
+    value && CheckEmailAddress.normal(value)
   end
 
   # To a database value (string)
   def serialize(value)
-    value && EmailAddress.normal(value)
+    value && CheckEmailAddress.normal(value)
   end
 end

--- a/lib/email_address/config.rb
+++ b/lib/email_address/config.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module EmailAddress
+module CheckEmailAddress
   # Global configurations and for default/unknown providers. Settings are:
   #
   # * dns_lookup:         :mx, :a, :off

--- a/lib/email_address/email_address_type.rb
+++ b/lib/email_address/email_address_type.rb
@@ -6,9 +6,9 @@
 # 1) Register your types
 #
 #    # config/initializers/email_address.rb
-#    ActiveRecord::Type.register(:email_address, EmailAddress::Address)
+#    ActiveRecord::Type.register(:email_address, CheckEmailAddress::Address)
 #    ActiveRecord::Type.register(:canonical_email_address,
-#                                EmailAddress::CanonicalEmailAddressType)
+#                                CheckEmailAddress::CanonicalCheckEmailAddressType)
 #
 # 2) Define your email address columns in your model class
 #
@@ -29,20 +29,20 @@
 #    user.canonical_email #=> "patsmith@gmail.com"
 ################################################################################
 
-class EmailAddress::EmailAddressType < ActiveRecord::Type::Value
+class CheckEmailAddress::CheckEmailAddressType < ActiveRecord::Type::Value
 
   # From user input, setter
   def cast(value)
-    super(EmailAddress.normal(value))
+    super(CheckEmailAddress.normal(value))
   end
 
   # From a database value
   def deserialize(value)
-    value && EmailAddress.normal(value)
+    value && CheckEmailAddress.normal(value)
   end
   #
   # To a database value (string)
   def serialize(value)
-    value && EmailAddress.normal(value)
+    value && CheckEmailAddress.normal(value)
   end
 end

--- a/lib/email_address/exchanger.rb
+++ b/lib/email_address/exchanger.rb
@@ -4,7 +4,7 @@ require 'resolv'
 require 'netaddr'
 require 'socket'
 
-module EmailAddress
+module CheckEmailAddress
   class Exchanger
     include Enumerable
 
@@ -36,7 +36,7 @@ module EmailAddress
     # Returns the provider name based on the MX-er host names, or nil if not matched
     def provider
       return @provider if defined? @provider
-      EmailAddress::Config.providers.each do |provider, config|
+      CheckEmailAddress::Config.providers.each do |provider, config|
         if config[:exchanger_match] && self.matches?(config[:exchanger_match])
           return @provider = provider
         end
@@ -70,7 +70,7 @@ module EmailAddress
 
     # Returns Array of domain names for the MX'ers, used to determine the Provider
     def domains
-      @_domains ||= mxers.map {|m| EmailAddress::Host.new(m.first).domain_name }.sort.uniq
+      @_domains ||= mxers.map {|m| CheckEmailAddress::Host.new(m.first).domain_name }.sort.uniq
     end
 
     # Returns an array of MX IP address (String) for the given email domain

--- a/lib/email_address/host.rb
+++ b/lib/email_address/host.rb
@@ -4,9 +4,9 @@ require 'resolv'
 require 'netaddr'
 require 'net/smtp'
 
-module EmailAddress
+module CheckEmailAddress
   ##############################################################################
-  # The EmailAddress Host is found on the right-hand side of the "@" symbol.
+  # The CheckEmailAddress Host is found on the right-hand side of the "@" symbol.
   # It can be:
   # * Host name (domain name with optional subdomain)
   # * International Domain Name, in Unicode (Display) or Punycode (DNS) format
@@ -211,7 +211,7 @@ module EmailAddress
     def find_provider # :nodoc:
       return self.provider if self.provider
 
-      EmailAddress::Config.providers.each do |provider, config|
+      CheckEmailAddress::Config.providers.each do |provider, config|
         if config[:host_match] && self.matches?(config[:host_match])
           return self.set_provider(provider, config)
         end
@@ -222,14 +222,14 @@ module EmailAddress
       provider = self.exchangers.provider
       if provider != :default
         self.set_provider(provider,
-          EmailAddress::Config.provider(provider))
+          CheckEmailAddress::Config.provider(provider))
       end
 
       self.provider ||= self.set_provider(:default)
     end
 
     def set_provider(name, provider_config={}) # :nodoc:
-      self.config = EmailAddress::Config.all_settings(provider_config, @config)
+      self.config = CheckEmailAddress::Config.all_settings(provider_config, @config)
       self.provider = name
     end
 
@@ -331,7 +331,7 @@ module EmailAddress
 
     # True if the :dns_lookup setting is enabled
     def dns_enabled?
-      [:mx, :a].include?(EmailAddress::Config.setting(:host_validation))
+      [:mx, :a].include?(CheckEmailAddress::Config.setting(:host_validation))
     end
 
     # Returns: [official_hostname, alias_hostnames, address_family, *address_list]
@@ -342,11 +342,11 @@ module EmailAddress
       @_dns_a_record ||= []
     end
 
-    # Returns an array of EmailAddress::Exchanger hosts configured in DNS.
+    # Returns an array of CheckEmailAddress::Exchanger hosts configured in DNS.
     # The array will be empty if none are configured.
     def exchangers
       #return nil if @config[:host_type] != :email || !self.dns_enabled?
-      @_exchangers ||= EmailAddress::Exchanger.cached(self.dns_name, @config)
+      @_exchangers ||= CheckEmailAddress::Exchanger.cached(self.dns_name, @config)
     end
 
     # Returns a DNS TXT Record
@@ -494,7 +494,7 @@ module EmailAddress
     def set_error(err, reason=nil)
       @error         = err
       @reason        = reason
-      @error_message = EmailAddress::Config.error_message(err)
+      @error_message = CheckEmailAddress::Config.error_message(err)
       false
     end
 

--- a/lib/email_address/local.rb
+++ b/lib/email_address/local.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-module EmailAddress
+module CheckEmailAddress
   ##############################################################################
-  # EmailAddress Local part consists of
+  # CheckEmailAddress Local part consists of
   # - comments
   # - mailbox
   # - tag
@@ -102,7 +102,7 @@ module EmailAddress
     REDACTED_REGEX = /\A \{ [0-9a-f]{40} \} \z/x # {sha1}
 
     def initialize(local, config={}, host=nil)
-      self.config   = config.empty? ? EmailAddress::Config.all_settings : config
+      self.config   = config.empty? ? CheckEmailAddress::Config.all_settings : config
       self.local    = local
       @host         = host
       @error        = @error_message = nil
@@ -375,7 +375,7 @@ module EmailAddress
     def set_error(err, reason=nil)
       @error = err
       @reason= reason
-      @error_message = EmailAddress::Config.error_message(err)
+      @error_message = CheckEmailAddress::Config.error_message(err)
       false
     end
 

--- a/lib/email_address/rewriter.rb
+++ b/lib/email_address/rewriter.rb
@@ -2,7 +2,7 @@
 
 require 'base64'
 
-module EmailAddress::Rewriter
+module CheckEmailAddress::Rewriter
 
   SRS_FORMAT_REGEX   = /\ASRS0=(....)=(\w\w)=(.+?)=(.+?)@(.+)\z/
 

--- a/lib/email_address/version.rb
+++ b/lib/email_address/version.rb
@@ -1,3 +1,3 @@
-module EmailAddress
+module CheckEmailAddress
   VERSION = "0.1.11"
 end

--- a/test/activerecord/user.rb
+++ b/test/activerecord/user.rb
@@ -32,9 +32,9 @@ ApplicationRecord.connection.execute(
   "create table users ( email varchar, canonical_email varchar)")
 
 if defined?(ActiveRecord) && ::ActiveRecord::VERSION::MAJOR >= 5
-  ActiveRecord::Type.register(:email_address, EmailAddress::EmailAddressType)
+  ActiveRecord::Type.register(:email_address, CheckEmailAddress::CheckEmailAddressType)
   ActiveRecord::Type.register(:canonical_email_address,
-                              EmailAddress::CanonicalEmailAddressType)
+                              CheckEmailAddress::CanonicalCheckEmailAddressType)
 end
 
 ################################################################################
@@ -48,7 +48,7 @@ class User < ApplicationRecord
     attribute :canonical_email, :canonical_email_address
   end
 
-  validates_with EmailAddress::ActiveRecordValidator,
+  validates_with CheckEmailAddress::ActiveRecordValidator,
     fields: %i(email canonical_email)
 
   def email=(email_address)
@@ -57,14 +57,14 @@ class User < ApplicationRecord
   end
 
   def self.find_by_email(email)
-    user   = self.find_by(email: EmailAddress.normal(email))
-    user ||= self.find_by(canonical_email: EmailAddress.canonical(email))
-    user ||= self.find_by(canonical_email: EmailAddress.redacted(email))
+    user   = self.find_by(email: CheckEmailAddress.normal(email))
+    user ||= self.find_by(canonical_email: CheckEmailAddress.canonical(email))
+    user ||= self.find_by(canonical_email: CheckEmailAddress.redacted(email))
     user
   end
 
   def redact!
-    self[:canonical_email] = EmailAddress.redact(self.canonical_email)
+    self[:canonical_email] = CheckEmailAddress.redact(self.canonical_email)
     self[:email]           = self[:canonical_email]
   end
 

--- a/test/email_address/test_address.rb
+++ b/test/email_address/test_address.rb
@@ -3,7 +3,7 @@ require_relative '../test_helper'
 
 class TestAddress < Minitest::Test
   def test_address
-    a = EmailAddress.new("User+tag@example.com")
+    a = CheckEmailAddress.new("User+tag@example.com")
     assert_equal "user+tag", a.local.to_s
     assert_equal "example.com", a.host.to_s
     assert_equal "us*****@ex*****", a.munge
@@ -12,7 +12,7 @@ class TestAddress < Minitest::Test
 
   # LOCAL
   def test_local
-    a = EmailAddress.new("User+tag@example.com")
+    a = CheckEmailAddress.new("User+tag@example.com")
     assert_equal "user", a.mailbox
     assert_equal "user+tag", a.left
     assert_equal "tag", a.tag
@@ -20,30 +20,30 @@ class TestAddress < Minitest::Test
 
   # HOST
   def test_host
-    a = EmailAddress.new("User+tag@example.com")
+    a = CheckEmailAddress.new("User+tag@example.com")
     assert_equal "example.com", a.hostname
     #assert_equal :default, a.provider
   end
 
   # ADDRESS
   def test_forms
-    a = EmailAddress.new("User+tag@example.com")
+    a = CheckEmailAddress.new("User+tag@example.com")
     assert_equal "user+tag@example.com", a.to_s
     assert_equal "user@example.com", a.base
     assert_equal "user@example.com", a.canonical
     assert_equal "{63a710569261a24b3766275b7000ce8d7b32e2f7}@example.com", a.redact
     assert_equal "{b58996c504c5638798eb6b511e6f49af}@example.com", a.redact(:md5)
     assert_equal "b58996c504c5638798eb6b511e6f49af", a.reference
-    assert_equal "6bdd00c53645790ad9bbcb50caa93880",  EmailAddress.reference("Gmail.User+tag@gmail.com")
+    assert_equal "6bdd00c53645790ad9bbcb50caa93880",  CheckEmailAddress.reference("Gmail.User+tag@gmail.com")
   end
 
   # COMPARISON & MATCHING
   def test_compare
     a = ("User+tag@example.com")
-    #e = EmailAddress.new("user@example.com")
-    n = EmailAddress.new(a)
-    c = EmailAddress.new_canonical(a)
-    #r = EmailAddress.new_redacted(a)
+    #e = CheckEmailAddress.new("user@example.com")
+    n = CheckEmailAddress.new(a)
+    c = CheckEmailAddress.new_canonical(a)
+    #r = CheckEmailAddress.new_redacted(a)
     assert_equal true, n == "user+tag@example.com"
     assert_equal true, n >  "b@example.com"
     assert_equal true, n.same_as?(c)
@@ -51,7 +51,7 @@ class TestAddress < Minitest::Test
   end
 
   def test_matches
-    a = EmailAddress.new("User+tag@gmail.com")
+    a = CheckEmailAddress.new("User+tag@gmail.com")
     assert_equal false,  a.matches?('mail.com')
     assert_equal 'google',  a.matches?('google')
     assert_equal 'user+tag@',  a.matches?('user+tag@')
@@ -59,7 +59,7 @@ class TestAddress < Minitest::Test
   end
 
   def test_empty_address
-    a = EmailAddress.new("")
+    a = CheckEmailAddress.new("")
     assert_equal "{9a78211436f6d425ec38f5c4e02270801f3524f8}", a.redact
     assert_equal "", a.to_s
     assert_equal "", a.canonical
@@ -68,52 +68,52 @@ class TestAddress < Minitest::Test
 
   # VALIDATION
   def test_valid
-    assert EmailAddress.valid?("User+tag@example.com", host_validation: :a), "valid 1"
-    assert ! EmailAddress.valid?("User%tag@example.com", host_validation: :a), "valid 2"
-    assert EmailAddress.new("ɹᴉɐℲuǝll∀@ɹᴉɐℲuǝll∀.ws", local_encoding: :uncode, host_validation: :syntax ), "valid unicode"
+    assert CheckEmailAddress.valid?("User+tag@example.com", host_validation: :a), "valid 1"
+    assert ! CheckEmailAddress.valid?("User%tag@example.com", host_validation: :a), "valid 2"
+    assert CheckEmailAddress.new("ɹᴉɐℲuǝll∀@ɹᴉɐℲuǝll∀.ws", local_encoding: :uncode, host_validation: :syntax ), "valid unicode"
   end
 
   def test_localhost
-    e = EmailAddress.new("User+tag.gmail.ws") # No domain means localhost
+    e = CheckEmailAddress.new("User+tag.gmail.ws") # No domain means localhost
     assert_equal '', e.hostname
     assert_equal false, e.valid? # localhost not allowed by default
-    assert_equal EmailAddress.error("user1"), "Invalid Domain Name"
-    assert_equal EmailAddress.error("user1", host_local:true), "This domain is not configured to accept email"
-    assert_equal EmailAddress.error("user1@localhost", host_local:true), "This domain is not configured to accept email"
-    assert_nil EmailAddress.error("user2@localhost", host_local:true, dns_lookup: :off, host_validation: :syntax)
+    assert_equal CheckEmailAddress.error("user1"), "Invalid Domain Name"
+    assert_equal CheckEmailAddress.error("user1", host_local:true), "This domain is not configured to accept email"
+    assert_equal CheckEmailAddress.error("user1@localhost", host_local:true), "This domain is not configured to accept email"
+    assert_nil CheckEmailAddress.error("user2@localhost", host_local:true, dns_lookup: :off, host_validation: :syntax)
   end
 
   def test_regexen
-    assert "First.Last+TAG@example.com".match(EmailAddress::Address::CONVENTIONAL_REGEX)
-    assert "First.Last+TAG@example.com".match(EmailAddress::Address::STANDARD_REGEX)
-    assert_nil "First.Last+TAGexample.com".match(EmailAddress::Address::STANDARD_REGEX)
-    assert_nil "First#Last+TAGexample.com".match(EmailAddress::Address::CONVENTIONAL_REGEX)
-    assert "aasdf-34-.z@example.com".match(EmailAddress::Address::RELAXED_REGEX)
+    assert "First.Last+TAG@example.com".match(CheckEmailAddress::Address::CONVENTIONAL_REGEX)
+    assert "First.Last+TAG@example.com".match(CheckEmailAddress::Address::STANDARD_REGEX)
+    assert_nil "First.Last+TAGexample.com".match(CheckEmailAddress::Address::STANDARD_REGEX)
+    assert_nil "First#Last+TAGexample.com".match(CheckEmailAddress::Address::CONVENTIONAL_REGEX)
+    assert "aasdf-34-.z@example.com".match(CheckEmailAddress::Address::RELAXED_REGEX)
   end
 
   def test_srs
     ea= "first.LAST+tag@gmail.com"
-    e = EmailAddress.new(ea)
+    e = CheckEmailAddress.new(ea)
     s = e.srs("example.com")
-    assert s.match(EmailAddress::Address::SRS_FORMAT_REGEX)
-    assert EmailAddress.new(s).to_s == e.to_s
+    assert s.match(CheckEmailAddress::Address::SRS_FORMAT_REGEX)
+    assert CheckEmailAddress.new(s).to_s == e.to_s
   end
 
   # Quick Regression tests for addresses that should have been valid (but fixed)
   def test_issues
-    assert true, EmailAddress.valid?('test@jiff.com', dns_lookup: :mx) # #7
-    assert true, EmailAddress.valid?("w.-asdf-_@hotmail.com") # #8
-    assert true, EmailAddress.valid?("first_last@hotmail.com") # #8
+    assert true, CheckEmailAddress.valid?('test@jiff.com', dns_lookup: :mx) # #7
+    assert true, CheckEmailAddress.valid?("w.-asdf-_@hotmail.com") # #8
+    assert true, CheckEmailAddress.valid?("first_last@hotmail.com") # #8
   end
 
   def test_issue9
-    assert ! EmailAddress.valid?('example.user@foo.')
-    assert ! EmailAddress.valid?('ogog@sss.c')
-    assert ! EmailAddress.valid?('example.user@foo.com/')
+    assert ! CheckEmailAddress.valid?('example.user@foo.')
+    assert ! CheckEmailAddress.valid?('ogog@sss.c')
+    assert ! CheckEmailAddress.valid?('example.user@foo.com/')
   end
 
   def test_relaxed_normal
-    assert ! EmailAddress.new('a.c.m.e.-industries@foo.com').valid?
-    assert true, EmailAddress.new('a.c.m.e.-industries@foo.com', local_format: :relaxed).valid?
+    assert ! CheckEmailAddress.new('a.c.m.e.-industries@foo.com').valid?
+    assert true, CheckEmailAddress.new('a.c.m.e.-industries@foo.com', local_format: :relaxed).valid?
   end
 end

--- a/test/email_address/test_config.rb
+++ b/test/email_address/test_config.rb
@@ -2,27 +2,27 @@ require_relative '../test_helper'
 
 class TestConfig < MiniTest::Test
   def test_setting
-    assert_equal :mx,  EmailAddress::Config.setting(:dns_lookup)
-    assert_equal :off, EmailAddress::Config.setting(:dns_lookup, :off)
-    assert_equal :off, EmailAddress::Config.setting(:dns_lookup)
-    EmailAddress::Config.setting(:dns_lookup, :mx)
+    assert_equal :mx,  CheckEmailAddress::Config.setting(:dns_lookup)
+    assert_equal :off, CheckEmailAddress::Config.setting(:dns_lookup, :off)
+    assert_equal :off, CheckEmailAddress::Config.setting(:dns_lookup)
+    CheckEmailAddress::Config.setting(:dns_lookup, :mx)
   end
 
   def test_configure
-    assert_equal :mx,   EmailAddress::Config.setting(:dns_lookup)
-    assert_equal true,  EmailAddress::Config.setting(:local_downcase)
-    EmailAddress::Config.configure(local_downcase:false, dns_lookup: :off)
-    assert_equal :off,  EmailAddress::Config.setting(:dns_lookup)
-    assert_equal false, EmailAddress::Config.setting(:local_downcase)
-    EmailAddress::Config.configure(local_downcase:true, dns_lookup: :mx)
+    assert_equal :mx,   CheckEmailAddress::Config.setting(:dns_lookup)
+    assert_equal true,  CheckEmailAddress::Config.setting(:local_downcase)
+    CheckEmailAddress::Config.configure(local_downcase:false, dns_lookup: :off)
+    assert_equal :off,  CheckEmailAddress::Config.setting(:dns_lookup)
+    assert_equal false, CheckEmailAddress::Config.setting(:local_downcase)
+    CheckEmailAddress::Config.configure(local_downcase:true, dns_lookup: :mx)
   end
 
   def test_provider
-    assert_nil EmailAddress::Config.provider(:github)
-    EmailAddress::Config.provider(:github, host_match: %w(github.com), local_format: :standard)
-    assert_equal :standard, EmailAddress::Config.provider(:github)[:local_format]
-    assert_equal :github, EmailAddress::Host.new("github.com").provider
-    EmailAddress::Config.providers.delete(:github)
-    assert_nil EmailAddress::Config.provider(:github)
+    assert_nil CheckEmailAddress::Config.provider(:github)
+    CheckEmailAddress::Config.provider(:github, host_match: %w(github.com), local_format: :standard)
+    assert_equal :standard, CheckEmailAddress::Config.provider(:github)[:local_format]
+    assert_equal :github, CheckEmailAddress::Host.new("github.com").provider
+    CheckEmailAddress::Config.providers.delete(:github)
+    assert_nil CheckEmailAddress::Config.provider(:github)
   end
 end

--- a/test/email_address/test_exchanger.rb
+++ b/test/email_address/test_exchanger.rb
@@ -3,7 +3,7 @@ require_relative '../test_helper'
 
 class TestExchanger < MiniTest::Test
   def test_exchanger
-    e = EmailAddress::Exchanger.new("gmail.com")
+    e = CheckEmailAddress::Exchanger.new("gmail.com")
     assert_equal true, e.mxers.size > 1
     assert_equal :google, e.provider
     assert_equal 'google.com', e.domains.first
@@ -14,14 +14,14 @@ class TestExchanger < MiniTest::Test
   end
 
   def test_not_found
-    e = EmailAddress::Exchanger.new("oops.gmail.com")
+    e = CheckEmailAddress::Exchanger.new("oops.gmail.com")
     assert_equal 0, e.mxers.size
   end
 
     #assert_equal true, a.has_dns_a_record? # example.com has no MX'ers
   #def test_dns
-  #  good = EmailAddress::Exchanger.new("gmail.com")
-  #  bad  = EmailAddress::Exchanger.new("exampldkeie4iufe.com")
+  #  good = CheckEmailAddress::Exchanger.new("gmail.com")
+  #  bad  = CheckEmailAddress::Exchanger.new("exampldkeie4iufe.com")
   #  assert_equal true, good.has_dns_a_record?
   #  assert_equal false, bad.has_dns_a_record?
   #  assert_equal "gmail.com", good.dns_a_record.first

--- a/test/email_address/test_host.rb
+++ b/test/email_address/test_host.rb
@@ -4,7 +4,7 @@ require_relative '../test_helper'
 
 class TestHost < MiniTest::Test
   def test_host
-    a = EmailAddress::Host.new("example.com")
+    a = CheckEmailAddress::Host.new("example.com")
     assert_equal "example.com", a.host_name
     assert_equal "example.com", a.domain_name
     assert_equal "example", a.registration_name
@@ -14,16 +14,16 @@ class TestHost < MiniTest::Test
   end
 
   def test_dns_enabled
-    a = EmailAddress::Host.new("example.com")
+    a = CheckEmailAddress::Host.new("example.com")
     assert_instance_of TrueClass, a.dns_enabled?
-    old_setting = EmailAddress::Config.setting(:host_validation)
-    EmailAddress::Config.configure(host_validation: :off)
+    old_setting = CheckEmailAddress::Config.setting(:host_validation)
+    CheckEmailAddress::Config.configure(host_validation: :off)
     assert_instance_of FalseClass, a.dns_enabled?
-    EmailAddress::Config.configure(host_validation: old_setting)
+    CheckEmailAddress::Config.configure(host_validation: old_setting)
   end
 
   def test_foreign_host
-    a = EmailAddress::Host.new("my.yahoo.co.jp")
+    a = CheckEmailAddress::Host.new("my.yahoo.co.jp")
     assert_equal "my.yahoo.co.jp", a.host_name
     assert_equal "yahoo.co.jp", a.domain_name
     assert_equal "yahoo", a.registration_name
@@ -32,55 +32,55 @@ class TestHost < MiniTest::Test
   end
 
   def test_ip_host
-    a = EmailAddress::Host.new("[127.0.0.1]")
+    a = CheckEmailAddress::Host.new("[127.0.0.1]")
     assert_equal "[127.0.0.1]", a.name
     assert_equal "127.0.0.1", a.ip_address
   end
 
   def test_unicode_host
-    a = EmailAddress::Host.new("å.com")
+    a = CheckEmailAddress::Host.new("å.com")
     assert_equal "xn--5ca.com", a.dns_name
-    a = EmailAddress::Host.new("xn--5ca.com", host_encoding: :unicode)
+    a = CheckEmailAddress::Host.new("xn--5ca.com", host_encoding: :unicode)
     assert_equal "å.com", a.to_s
   end
 
   def test_provider
-    a = EmailAddress::Host.new("my.yahoo.co.jp")
+    a = CheckEmailAddress::Host.new("my.yahoo.co.jp")
     assert_equal :yahoo, a.provider
-    a = EmailAddress::Host.new("example.com")
+    a = CheckEmailAddress::Host.new("example.com")
     assert_equal :default, a.provider
   end
 
   def test_dmarc
-    d = EmailAddress::Host.new("yahoo.com").dmarc
+    d = CheckEmailAddress::Host.new("yahoo.com").dmarc
     assert_equal 'reject', d[:p]
-    d = EmailAddress::Host.new("example.com").dmarc
+    d = CheckEmailAddress::Host.new("example.com").dmarc
     assert_equal true, d.empty?
   end
 
   def test_ipv4
-    h = EmailAddress::Host.new("[127.0.0.1]", host_allow_ip:true, host_local:true)
+    h = CheckEmailAddress::Host.new("[127.0.0.1]", host_allow_ip:true, host_local:true)
     assert_equal "127.0.0.1", h.ip_address
     assert_equal true, h.valid?
   end
 
   def test_ipv6
-    h = EmailAddress::Host.new("[IPv6:::1]", host_allow_ip:true, host_local:true)
+    h = CheckEmailAddress::Host.new("[IPv6:::1]", host_allow_ip:true, host_local:true)
     assert_equal "::1", h.ip_address
     assert_equal true, h.valid?
   end
 
   def test_comment
-    h = EmailAddress::Host.new("(oops)gmail.com")
+    h = CheckEmailAddress::Host.new("(oops)gmail.com")
     assert_equal 'gmail.com', h.to_s
     assert_equal 'oops', h.comment
-    h = EmailAddress::Host.new("gmail.com(oops)")
+    h = CheckEmailAddress::Host.new("gmail.com(oops)")
     assert_equal 'gmail.com', h.to_s
     assert_equal 'oops', h.comment
   end
 
   def test_matches
-    h = EmailAddress::Host.new("yahoo.co.jp")
+    h = CheckEmailAddress::Host.new("yahoo.co.jp")
     assert_equal false, h.matches?("gmail.com")
     assert_equal 'yahoo.co.jp', h.matches?("yahoo.co.jp")
     assert_equal '.co.jp', h.matches?(".co.jp")
@@ -90,36 +90,36 @@ class TestHost < MiniTest::Test
   end
 
   def test_regexen
-    assert "asdf.com".match EmailAddress::Host::CANONICAL_HOST_REGEX
-    assert "xn--5ca.com".match EmailAddress::Host::CANONICAL_HOST_REGEX
-    assert "[127.0.0.1]".match EmailAddress::Host::STANDARD_HOST_REGEX
-    assert "[IPv6:2001:dead::1]".match EmailAddress::Host::STANDARD_HOST_REGEX
-    assert_nil "[256.0.0.1]".match(EmailAddress::Host::STANDARD_HOST_REGEX)
+    assert "asdf.com".match CheckEmailAddress::Host::CANONICAL_HOST_REGEX
+    assert "xn--5ca.com".match CheckEmailAddress::Host::CANONICAL_HOST_REGEX
+    assert "[127.0.0.1]".match CheckEmailAddress::Host::STANDARD_HOST_REGEX
+    assert "[IPv6:2001:dead::1]".match CheckEmailAddress::Host::STANDARD_HOST_REGEX
+    assert_nil "[256.0.0.1]".match(CheckEmailAddress::Host::STANDARD_HOST_REGEX)
   end
 
   def test_hosted_service
-    assert EmailAddress.valid?('test@jiff.com', dns_lookup: :mx)
-    assert ! EmailAddress.valid?('test@gmail.com', dns_lookup: :mx)
+    assert CheckEmailAddress.valid?('test@jiff.com', dns_lookup: :mx)
+    assert ! CheckEmailAddress.valid?('test@gmail.com', dns_lookup: :mx)
   end
 
   def test_yahoo_bad_tld
-    assert ! EmailAddress.valid?('test@yahoo.badtld')
-    assert ! EmailAddress.valid?('test@yahoo.wtf') # Registered, but MX IP = 0.0.0.0
+    assert ! CheckEmailAddress.valid?('test@yahoo.badtld')
+    assert ! CheckEmailAddress.valid?('test@yahoo.wtf') # Registered, but MX IP = 0.0.0.0
   end
 
   def test_bad_formats
-    assert ! EmailAddress::Host.new('ya  hoo.com').valid?
-    assert EmailAddress::Host.new('ya  hoo.com', host_remove_spaces:true).valid?
+    assert ! CheckEmailAddress::Host.new('ya  hoo.com').valid?
+    assert CheckEmailAddress::Host.new('ya  hoo.com', host_remove_spaces:true).valid?
   end
 
   def test_errors
-    assert_nil EmailAddress::Host.new("yahoo.com").error
-    assert_equal EmailAddress::Host.new("example.com").error, "This domain is not configured to accept email"
-    assert_equal EmailAddress::Host.new("yahoo.wtf").error, "Domain name not registered"
-    assert_nil EmailAddress::Host.new("ajsdfhajshdfklasjhd.wtf", host_validation: :syntax).error
-    assert_equal EmailAddress::Host.new("ya  hoo.com", host_validation: :syntax).error, "Invalid Domain Name"
-    assert_equal EmailAddress::Host.new("[127.0.0.1]").error, "IP Addresses are not allowed"
-    assert_equal EmailAddress::Host.new("[127.0.0.666]", host_allow_ip:true).error, "This is not a valid IPv4 address"
-    assert_equal EmailAddress::Host.new("[IPv6::12t]", host_allow_ip:true).error, "This is not a valid IPv6 address"
+    assert_nil CheckEmailAddress::Host.new("yahoo.com").error
+    assert_equal CheckEmailAddress::Host.new("example.com").error, "This domain is not configured to accept email"
+    assert_equal CheckEmailAddress::Host.new("yahoo.wtf").error, "Domain name not registered"
+    assert_nil CheckEmailAddress::Host.new("ajsdfhajshdfklasjhd.wtf", host_validation: :syntax).error
+    assert_equal CheckEmailAddress::Host.new("ya  hoo.com", host_validation: :syntax).error, "Invalid Domain Name"
+    assert_equal CheckEmailAddress::Host.new("[127.0.0.1]").error, "IP Addresses are not allowed"
+    assert_equal CheckEmailAddress::Host.new("[127.0.0.666]", host_allow_ip:true).error, "This is not a valid IPv4 address"
+    assert_equal CheckEmailAddress::Host.new("[IPv6::12t]", host_allow_ip:true).error, "This is not a valid IPv6 address"
   end
 end

--- a/test/email_address/test_local.rb
+++ b/test/email_address/test_local.rb
@@ -18,7 +18,7 @@ class TestLocal < MiniTest::Test
       %Q{token." ".token},
       %Q{abc."defghi".xyz},
     ].each do |local|
-      assert EmailAddress::Local.new(local, local_fix: false).standard?, local
+      assert CheckEmailAddress::Local.new(local, local_fix: false).standard?, local
     end
   end
 
@@ -34,69 +34,69 @@ class TestLocal < MiniTest::Test
       %Q{invalid },
       %Q{abc"defghi"xyz},
     ].each do |local|
-      assert_equal false, EmailAddress::Local.new(local, local_fix: false).standard?, local
+      assert_equal false, CheckEmailAddress::Local.new(local, local_fix: false).standard?, local
     end
   end
 
   def test_relaxed
-    assert EmailAddress::Local.new("first..last", local_format: :relaxed).valid?, "relax.."
-    assert EmailAddress::Local.new("first.-last", local_format: :relaxed).valid?, "relax.-"
-    assert EmailAddress::Local.new("a", local_format: :relaxed).valid?, "relax single"
-    assert ! EmailAddress::Local.new("firstlast_", local_format: :relaxed).valid?, "last_"
+    assert CheckEmailAddress::Local.new("first..last", local_format: :relaxed).valid?, "relax.."
+    assert CheckEmailAddress::Local.new("first.-last", local_format: :relaxed).valid?, "relax.-"
+    assert CheckEmailAddress::Local.new("a", local_format: :relaxed).valid?, "relax single"
+    assert ! CheckEmailAddress::Local.new("firstlast_", local_format: :relaxed).valid?, "last_"
   end
 
   def test_unicode
-    assert ! EmailAddress::Local.new("üñîçøðé1", local_encoding: :ascii).standard?, "not üñîçøðé1"
-    assert EmailAddress::Local.new("üñîçøðé2", local_encoding: :unicode).standard?, "üñîçøðé2"
-    assert EmailAddress::Local.new("test", local_encoding: :unicode).valid?, "unicode should include ascii"
-    assert ! EmailAddress::Local.new("üñîçøðé3").valid?, "üñîçøðé3 valid"
+    assert ! CheckEmailAddress::Local.new("üñîçøðé1", local_encoding: :ascii).standard?, "not üñîçøðé1"
+    assert CheckEmailAddress::Local.new("üñîçøðé2", local_encoding: :unicode).standard?, "üñîçøðé2"
+    assert CheckEmailAddress::Local.new("test", local_encoding: :unicode).valid?, "unicode should include ascii"
+    assert ! CheckEmailAddress::Local.new("üñîçøðé3").valid?, "üñîçøðé3 valid"
   end
 
 
   def test_valid_conventional
     %w( first.last first First+Tag o'brien).each do |local|
-      assert EmailAddress::Local.new(local).conventional?, local
+      assert CheckEmailAddress::Local.new(local).conventional?, local
     end
   end
 
   def test_invalid_conventional
     (%w( first;.last +leading trailing+ o%brien) + ["first space"]).each do |local|
-      assert ! EmailAddress::Local.new(local, local_fix:false).conventional?, local
+      assert ! CheckEmailAddress::Local.new(local, local_fix:false).conventional?, local
     end
   end
 
   def test_valid
-    assert_equal false, EmailAddress::Local.new("first(comment)", local_format: :conventional).valid?
-    assert_equal true, EmailAddress::Local.new("first(comment)", local_format: :standard).valid?
+    assert_equal false, CheckEmailAddress::Local.new("first(comment)", local_format: :conventional).valid?
+    assert_equal true, CheckEmailAddress::Local.new("first(comment)", local_format: :standard).valid?
   end
 
   def test_format
-    assert_equal :conventional, EmailAddress::Local.new("can1").format?
-    assert_equal :standard, EmailAddress::Local.new(%Q{"can1"}).format?
-    assert_equal "can1", EmailAddress::Local.new(%Q{"can1(commment)"}).format(:conventional)
+    assert_equal :conventional, CheckEmailAddress::Local.new("can1").format?
+    assert_equal :standard, CheckEmailAddress::Local.new(%Q{"can1"}).format?
+    assert_equal "can1", CheckEmailAddress::Local.new(%Q{"can1(commment)"}).format(:conventional)
   end
 
   def test_redacted
     l = "{bea3f3560a757f8142d38d212a931237b218eb5e}"
-    assert EmailAddress::Local.redacted?(l), "redacted? #{l}"
-    assert_equal :redacted, EmailAddress::Local.new(l).format?
+    assert CheckEmailAddress::Local.redacted?(l), "redacted? #{l}"
+    assert_equal :redacted, CheckEmailAddress::Local.new(l).format?
   end
 
   def test_matches
-    a = EmailAddress.new("User+tag@gmail.com")
+    a = CheckEmailAddress.new("User+tag@gmail.com")
     assert_equal false,  a.matches?('user')
     assert_equal false,  a.matches?('user@')
     assert_equal 'user*@',  a.matches?('user*@')
   end
 
   def test_munge
-    assert_equal "us*****", EmailAddress::Local.new("User+tag").munge
+    assert_equal "us*****", CheckEmailAddress::Local.new("User+tag").munge
   end
 
   def test_hosted
-    assert EmailAddress.valid?("x@exposure.co")
-    assert EmailAddress.error("xxxx+subscriber@gmail.com")
-    assert EmailAddress.valid?("xxxxx+subscriber@gmail.com")
+    assert CheckEmailAddress.valid?("x@exposure.co")
+    assert CheckEmailAddress.error("xxxx+subscriber@gmail.com")
+    assert CheckEmailAddress.valid?("xxxxx+subscriber@gmail.com")
   end
 
 end

--- a/test/email_address/test_rewriter.rb
+++ b/test/email_address/test_rewriter.rb
@@ -5,10 +5,10 @@ class TestRewriter < Minitest::Test
 
   def test_srs
     ea= "first.LAST+tag@gmail.com"
-    e = EmailAddress.new(ea)
+    e = CheckEmailAddress.new(ea)
     s = e.srs("example.com")
-    assert s.match(EmailAddress::Address::SRS_FORMAT_REGEX)
-    assert EmailAddress.new(s).to_s == e.to_s
+    assert s.match(CheckEmailAddress::Address::SRS_FORMAT_REGEX)
+    assert CheckEmailAddress.new(s).to_s == e.to_s
   end
 
 end

--- a/test/test_email_address.rb
+++ b/test/test_email_address.rb
@@ -1,51 +1,51 @@
 # encoding: UTF-8
 require_relative 'test_helper'
 
-class TestEmailAddress < MiniTest::Test
+class TestCheckEmailAddress < MiniTest::Test
 
   def test_new
-    a = EmailAddress.new('user@example.com')
+    a = CheckEmailAddress.new('user@example.com')
     assert_equal 'user', a.local.to_s
     assert_equal 'example.com', a.host.to_s
   end
 
   def test_canonical
-    assert_equal "firstlast@gmail.com", EmailAddress.canonical('First.Last+TAG@gmail.com')
-    a = EmailAddress.new_canonical('First.Last+TAG@gmail.com')
+    assert_equal "firstlast@gmail.com", CheckEmailAddress.canonical('First.Last+TAG@gmail.com')
+    a = CheckEmailAddress.new_canonical('First.Last+TAG@gmail.com')
     assert_equal 'firstlast', a.local.to_s
   end
 
   def test_normal
-    assert_equal 'user+tag@gmail.com', EmailAddress.normal('USER+TAG@GMAIL.com')
+    assert_equal 'user+tag@gmail.com', CheckEmailAddress.normal('USER+TAG@GMAIL.com')
   end
 
   def test_valid
-    assert_equal true, EmailAddress.valid?('user@yahoo.com')
-    assert_equal true, EmailAddress.valid?('a@yahoo.com')
+    assert_equal true, CheckEmailAddress.valid?('user@yahoo.com')
+    assert_equal true, CheckEmailAddress.valid?('a@yahoo.com')
   end
 
   def test_matches
-    assert_equal 'yahoo.', EmailAddress.matches?('user@yahoo.com', 'yahoo.')
+    assert_equal 'yahoo.', CheckEmailAddress.matches?('user@yahoo.com', 'yahoo.')
   end
 
   def test_reference
-    assert_equal 'dfeafc750cecde54f9a4775f5713bf01', EmailAddress.reference('user@yahoo.com')
+    assert_equal 'dfeafc750cecde54f9a4775f5713bf01', CheckEmailAddress.reference('user@yahoo.com')
   end
 
   def test_redact
-    assert_equal '{e037b6c476357f34f92b8f35b25d179a4f573f1e}@yahoo.com', EmailAddress.redact('user@yahoo.com')
+    assert_equal '{e037b6c476357f34f92b8f35b25d179a4f573f1e}@yahoo.com', CheckEmailAddress.redact('user@yahoo.com')
   end
 
   def test_cases
     %w( miles.o'brien@yahoo.com first.last@gmail.com a-b.c_d+e@f.gx
     ).each do |address|
-      assert EmailAddress.valid?(address, host_validation: :syntax), "valid?(#{address})"
+      assert CheckEmailAddress.valid?(address, host_validation: :syntax), "valid?(#{address})"
     end
   end
 
   def test_empty
-    assert_equal "", EmailAddress.normal("")
-    assert_equal "", EmailAddress.normal(" ")
+    assert_equal "", CheckEmailAddress.normal("")
+    assert_equal "", CheckEmailAddress.normal(" ")
   end
 
 end


### PR DESCRIPTION
While this PR does introduce a breaking change, I do think it should be considered. With the main namespace being EmailAddress, it will override my EmailAddress model in my app. 
My guess is that most people looking for a gem to validate email addresses probably have an email_addresses table in their app as well, deeming this gem unusable without forking or hacking or what else.

The best hack I could get to do so was initializing this gem with 
```
path = `bundle show email_address`.strip

Dir[path + '/**/*.rb'].each do |file_name|
  file = File.open(file_name, 'r')
  file_text = file.read
  file.close
  unless file_text.include?('CheckEmailAddress')
    file_text.gsub!('EmailAddress', 'CheckEmailAddress')
    File.open(file_name, 'w') { |f| f << file_text }
  end
end
```

This hack is so far from ideal, that I am making this PR in hopes that you may consider :)

This gem is far superior to any others out there, valid_email2, email_validator, etc., but doesn't have nearly as many downloads... possibly because of this reason