### PR TITLE
Upgraded netaddr to a minimum of 2.0.4

### DIFF
--- a/email_address.gemspec
+++ b/email_address.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
 
   spec.add_dependency "simpleidn"
-  spec.add_dependency "netaddr", "~> 2.0.4"
+  spec.add_dependency "netaddr", '>= 2.0.4', '< 3'
 end

--- a/email_address.gemspec
+++ b/email_address.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
 
   spec.add_dependency "simpleidn"
-  spec.add_dependency "netaddr", "~> 2.0"
+  spec.add_dependency "netaddr", "~> 2.0.4"
 end


### PR DESCRIPTION
Addresses: https://nvd.nist.gov/vuln/detail/CVE-2019-17383

"The netaddr gem before 2.0.4 for Ruby has misconfigured file permissions, such that a gem install may result in 0777 permissions in the target filesystem."