### PR TITLE
MX validation behaves inconsistently depending on network connectivity

### DIFF
--- a/lib/email_address/host.rb
+++ b/lib/email_address/host.rb
@@ -332,12 +332,11 @@ module EmailAddress
       [:mx, :a].include?(EmailAddress::Config.setting(:host_validation))
     end
 
-    # Returns: [official_hostname, alias_hostnames, address_family, *address_list]
+    # Returns: [official_hostname, [alias'], address_family, *address_list]
     def dns_a_record
-      @_dns_a_record = "0.0.0.0" if @config[:dns_lookup] == :off
-      @_dns_a_record ||= Socket.gethostbyname(self.dns_name)
-    rescue SocketError # not found, but could also mean network not work
-      @_dns_a_record ||= []
+      return [self.dns_name, [], 2, ""] if @config[:dns_lookup] == :off
+
+      @_dns_a_record = exchangers.a_record
     end
 
     # Returns an array of EmailAddress::Exchanger hosts configured in DNS.


### PR DESCRIPTION
**Description:** Validation gives inconsistent results depending on network status.

**Reproduction:**

1. Turn off your network connection.
1. Do the following:

    ```
    irb(main):001:0> require 'email_address'
    => true
    irb(main):002:0> EmailAddress::Config.configure(host_validation: :mx)
    => {:dns_lookup=>:mx, :sha1_secret=>"", :munge_string=>"*****", :local_downcase=>true, :local_fix=>false, :local_encoding=>:ascii, :local_parse=>nil, :local_format=>:conventional, :local_size=>1..64, :tag_separator=>"+", :mailbox_size=>1..64, :mailbox_canonical=>nil, :mailbox_validator=>nil, :host_encoding=>:punycode, :host_validation=>:mx, :host_size=>1..253, :host_allow_ip=>false, :host_remove_spaces=>false, :host_local=>false, :address_validation=>:parts, :address_size=>3..254, :address_fqdn_domain=>nil}
    irb(main):003:0> EmailAddress.error('somename@gmail.com')
    => "Domain name not registered"
    ```
    
1. Turn your network connection back on.
1. In the same IRB session, with connectivity restored:

    ```
    irb(main):004:0> EmailAddress.error('somename@gmail.com')
    => "This domain is not configured to accept email"
    ```

1. Start a new IRB session:

    ```
    irb(main):001:0> require 'email_address'
    => true
    irb(main):002:0> EmailAddress::Config.configure(host_validation: :mx)
    => {:dns_lookup=>:mx, :sha1_secret=>"", :munge_string=>"*****", :local_downcase=>true, :local_fix=>false, :local_encoding=>:ascii, :local_parse=>nil, :local_format=>:conventional, :local_size=>1..64, :tag_separator=>"+", :mailbox_size=>1..64, :mailbox_canonical=>nil, :mailbox_validator=>nil, :host_encoding=>:punycode, :host_validation=>:mx, :host_size=>1..253, :host_allow_ip=>false, :host_remove_spaces=>false, :host_local=>false, :address_validation=>:parts, :address_size=>3..254, :address_fqdn_domain=>nil}
    irb(main):003:0> EmailAddress.error('somename@gmail.com')
    => nil
    ```

**Expected Behavior:** Seems like if there's no network connection, it should raise a warning about MX not being able to validate, not report that validation has failed. Also, it definitely shouldn't report `"This domain is not configured to accept email"` about `gmail.com` at any point. Whatever is giving that report on that domain is pretty much by definition incorrect.