### PR TITLE
Fixes #54 old MSN addresses may start with a digit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - ruby-head
+  - 2.7.0
   - 2.3.7
   - jruby-9.2.9.0
   #- rbx

--- a/email_address.gemspec
+++ b/email_address.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency "activerecord", "=  4.2.10"
     spec.add_development_dependency "activerecord-jdbcsqlite3-adapter", '~> 1.3.24'
   else
-    spec.add_development_dependency "activerecord", "~> 5.2.0"
+    spec.add_development_dependency "activerecord", "~> 5.2.4"
     spec.add_development_dependency "sqlite3"
   end
   #spec.add_development_dependency "codeclimate-test-reporter"

--- a/lib/email_address/config.rb
+++ b/lib/email_address/config.rb
@@ -143,7 +143,7 @@ module EmailAddress
       },
       msn: {
         host_match:       %w(msn. hotmail. outlook. live.),
-        mailbox_validator: ->(m,t) { m =~ /\A[a-z][\-\w]*(?:\.[\-\w]+)*\z/i},
+        mailbox_validator: ->(m,t) { m =~ /\A\w[\-\w]*(?:\.[\-\w]+)*\z/i},
       },
       yahoo: {
         host_match:       %w(yahoo. ymail. rocketmail.),


### PR DESCRIPTION
Issue #8 details that _new_ addresses may only start with a letter.

I have seen valid emails like '0xxx@live.com' in the wild, which can no
longer be created, but do still exist.

I altered the regular expression to start with an letter or digit.