### PR TITLE
Use a match regex function that is compatible with older Ruby versions

### DIFF
--- a/email_address.gemspec
+++ b/email_address.gemspec
@@ -4,14 +4,15 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'email_address/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "email_address"
-  spec.version       = EmailAddress::VERSION
-  spec.authors       = ["Allen Fair"]
-  spec.email         = ["allen.fair@gmail.com"]
-  spec.description   = %q{The EmailAddress Gem to work with and validate email addresses.}
-  spec.summary       = %q{This gem provides a ruby language library for working with and validating email addresses. By default, it validates against conventional usage, the format preferred for user email addresses. It can be configured to validate against RFC “Standard” formats, common email service provider formats, and perform DNS validation.}
-  spec.homepage      = "https://github.com/afair/email_address"
-  spec.license       = "MIT"
+  spec.name                   = "email_address"
+  spec.version                = EmailAddress::VERSION
+  spec.authors                = ["Allen Fair"]
+  spec.email                  = ["allen.fair@gmail.com"]
+  spec.description            = %q{The EmailAddress Gem to work with and validate email addresses.}
+  spec.summary                = %q{This gem provides a ruby language library for working with and validating email addresses. By default, it validates against conventional usage, the format preferred for user email addresses. It can be configured to validate against RFC “Standard” formats, common email service provider formats, and perform DNS validation.}
+  spec.homepage               = "https://github.com/afair/email_address"
+  spec.license                = "MIT"
+  spec.required_ruby_version  = ">= 2.4.0"
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/lib/email_address/host.rb
+++ b/lib/email_address/host.rb
@@ -149,7 +149,7 @@ module EmailAddress
       if @config[:host_remove_spaces]
         @host_name = @host_name.delete(" ")
       end
-      @dns_name = if /[^[:ascii:]]/.match?(host_name)
+      @dns_name = if /[^[:ascii:]]/.match(host_name)
         ::SimpleIDN.to_ascii(host_name)
       else
         host_name

--- a/lib/email_address/host.rb
+++ b/lib/email_address/host.rb
@@ -149,7 +149,7 @@ module EmailAddress
       if @config[:host_remove_spaces]
         @host_name = @host_name.delete(" ")
       end
-      @dns_name = if /[^[:ascii:]]/.match(host_name)
+      @dns_name = if /[^[:ascii:]]/.match?(host_name)
         ::SimpleIDN.to_ascii(host_name)
       else
         host_name


### PR DESCRIPTION
Version 0.1.15 is incompatible with older Ruby versions because of the usage of `match?`.
This change should be compatible with all versions.