### PR TITLE
Remove "address_local" config doc from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,9 +544,6 @@ For the mailbox (AKA account, role), without the tag
 * address_size:       3..254,
   A range specifying the size limit of the complete address
 
-* address_local:      false,
-  Allow localhost, no domain, or local subdomains.
-
 For provider rules to match to domain names and Exchanger hosts
 The value is an array of match tokens.
 * host_match:         %w(.org example.com hotmail. user*@ sub.*.com)


### PR DESCRIPTION
We referenced the `address_local` configuration option in our README, but do not implement it.
According to the discussion in #65 it seems that this feature is not going to be implemented, therfore it's description is removed from the README.

closes #65