### PR TITLE
Use I18n strings if available

### DIFF
--- a/lib/email_address/active_record_validator.rb
+++ b/lib/email_address/active_record_validator.rb
@@ -38,7 +38,7 @@ module EmailAddress
       e = Address.new(r[f])
       unless e.valid?
         r.errors[f] << (@opt[:message] ||
-                       Config.error_messages[:invalid_address] ||
+                       Config.error_message(:invalid_address) ||
                        "Invalid Email Address")
       end
     end

--- a/lib/email_address/config.rb
+++ b/lib/email_address/config.rb
@@ -182,7 +182,9 @@ module EmailAddress
     end
 
     def self.error_message(name, locale = "en")
-      @errors[locale]["email_address"][name.to_s] || name.to_s
+      I18n.t!("email_address.#{name}")
+    rescue StandardError
+      @errors[locale]["email_address"][name.to_s]
     end
 
     # Customize your own error message text.


### PR DESCRIPTION
Tries to call `I18n.t!("email_address.#{name}")` at `error_message()`.
This could raise exceptions in two cases:
 - `I18n` doesn't exist (because you are not on Rails)
 - The key was not found on i18n YAML files for the current locale
 Both cases are caught by the rescue clause, which returns a string based on existing `@errors`.
 Now it's possible to define translations inside your Rails app in the regular way.