### PR TITLE
Fix deprecation warning on Rails 6.1

### DIFF
--- a/lib/email_address/active_record_validator.rb
+++ b/lib/email_address/active_record_validator.rb
@@ -37,9 +37,10 @@ module EmailAddress
       return if r[f].nil?
       e = Address.new(r[f])
       unless e.valid?
-        r.errors[f] << (@opt[:message] ||
-                       Config.error_messages[:invalid_address] ||
-                       "Invalid Email Address")
+        error_message = @opt[:message] ||
+                        Config.error_messages[:invalid_address] ||
+                        "Invalid Email Address"
+        r.errors.add(f, error_message)
       end
     end
 


### PR DESCRIPTION
In Rails 6.1, adding an error directly to an Active Record object using `<<` will raise the following deprecation warning:

```
DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead.
```

This pull request fixes the deprecation by using `ActiveModel::Errors#add` when setting errors to the Active Record object.