### PR TITLE
Docs: #reference and #sha1 use base, not canonical [ci skip]

### DIFF
--- a/lib/email_address/address.rb
+++ b/lib/email_address/address.rb
@@ -159,7 +159,7 @@ module EmailAddress
       [local.munge, host.munge].join("@")
     end
 
-    # Returns and MD5 of the canonical address form. Some cross-system systems
+    # Returns and MD5 of the base address form. Some cross-system systems
     # use the email address MD5 instead of the actual address to refer to the
     # same shared user identity without exposing the actual address when it
     # is not known in common.
@@ -168,7 +168,7 @@ module EmailAddress
     end
     alias md5 reference
 
-    # This returns the SHA1 digest (in a hex string) of the canonical email
+    # This returns the SHA1 digest (in a hex string) of the base email
     # address. See #md5 for more background.
     def sha1(form = :base)
       Digest::SHA1.hexdigest((send(form) || "") + (@config[:sha1_secret] || ""))


### PR DESCRIPTION
Update slightly misleading docs, as base and canonical aren't always the same. 

```ruby
EmailAddress.new('foo.bar+test@gmail.com')
# canonical = foobar@gmail.com
# base = foo.bar@gmail.com
# reference = c6ddb5cb7fa09b544e5bc11419bc0e90

EmailAddress.new('f.oo.bar+test@gmail.com')
# canonical = foobar@gmail.com
# base = f.oo.bar@gmail.com
# reference = 7878007991d9ca6ce5a3f71e79ce8ea9
```