### PR TITLE
I18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,25 @@ class User < ActiveRecord::Base
 end
 ```
 
+#### Rails I18n
+
+Copy and adapt `lib/email_address/messages.yaml` into your locales and
+create an after initialization callback:
+
+```ruby
+# config/initializers/email_address.rb
+
+Rails.application.config.after_initialize do
+  I18n.available_locales.each do |locale|
+    translations = I18n.t(:email_address, locale: locale)
+
+    next unless translations.is_a? Hash
+
+    EmailAddress::Config.error_messages translations.transform_keys(&:to_s), locale.to_s
+  end
+end
+```
+
 #### Rails Email Address Type Attribute
 
 Initial support is provided for Active Record 5.0 attributes API.

--- a/lib/email_address.rb
+++ b/lib/email_address.rb
@@ -49,21 +49,21 @@ module EmailAddress
 
     # Creates an instance of this email address.
     # This is a short-cut to EmailAddress::Address.new
-    def new(email_address, config={})
-      Address.new(email_address, config)
+    def new(email_address, config={}, locale = 'en')
+      Address.new(email_address, config, locale)
     end
 
-    def new_redacted(email_address, config={})
-      Address.new(Address.new(email_address, config).redact)
+    def new_redacted(email_address, config={}, locale = 'en')
+      Address.new(Address.new(email_address, config, locale).redact)
     end
 
-    def new_canonical(email_address, config={})
-      Address.new(Address.new(email_address, config).canonical, config)
+    def new_canonical(email_address, config={}, locale = 'en')
+      Address.new(Address.new(email_address, config, locale).canonical, config)
     end
 
     # Does the email address match any of the given rules
-    def matches?(email_address, rules, config={})
-      Address.new(email_address, config).matches?(rules)
+    def matches?(email_address, rules, config={}, locale = 'en')
+      Address.new(email_address, config, locale).matches?(rules)
     end
   end
 end

--- a/lib/email_address/active_record_validator.rb
+++ b/lib/email_address/active_record_validator.rb
@@ -38,7 +38,7 @@ module EmailAddress
       e = Address.new(r[f])
       unless e.valid?
         error_message = @opt[:message] ||
-                        Config.error_messages[:invalid_address] ||
+                        Config.error_message(:invalid_address, I18n.locale.to_s) ||
                         "Invalid Email Address"
         r.errors.add(f, error_message)
       end

--- a/lib/email_address/address.rb
+++ b/lib/email_address/address.rb
@@ -10,7 +10,7 @@ module EmailAddress
     include Comparable
     include Rewriter
 
-    attr_accessor :original, :local, :host, :config, :reason
+    attr_accessor :original, :local, :host, :config, :reason, :locale
 
     CONVENTIONAL_REGEX = /\A#{Local::CONVENTIONAL_MAILBOX_WITHIN}
                            @#{Host::DNS_HOST_REGEX}\z/x
@@ -22,15 +22,16 @@ module EmailAddress
     # Given an email address of the form "local@hostname", this sets up the
     # instance, and initializes the address to the "normalized" format of the
     # address. The original string is available in the #original method.
-    def initialize(email_address, config = {})
+    def initialize(email_address, config = {}, locale = "en")
       @config = Config.new(config)
       @original = email_address
+      @locale = locale
       email_address = (email_address || "").strip
       email_address = parse_rewritten(email_address) unless config[:skip_rewrite]
       local, host = Address.split_local_host(email_address)
 
-      @host = Host.new(host, @config)
-      @local = Local.new(local, @config, @host)
+      @host = Host.new(host, @config, locale)
+      @local = Local.new(local, @config, @host, locale)
       @error = @error_message = nil
     end
 
@@ -276,7 +277,7 @@ module EmailAddress
     def set_error(err, reason = nil)
       @error = err
       @reason = reason
-      @error_message = Config.error_message(err)
+      @error_message = Config.error_message(err, locale)
       false
     end
 

--- a/lib/email_address/config.rb
+++ b/lib/email_address/config.rb
@@ -188,9 +188,13 @@ module EmailAddress
     # Customize your own error message text.
     def self.error_messages(hash = {}, locale = "en", *extra)
       hash = extra.first if extra.first.is_a? Hash
+      @errors[locale] ||= {}
+      @errors[locale]["email_address"] ||= {}
+
       unless hash.empty?
         @errors[locale]["email_address"] = @errors[locale]["email_address"].merge(hash)
       end
+
       @errors[locale]["email_address"]
     end
 

--- a/lib/email_address/config.rb
+++ b/lib/email_address/config.rb
@@ -188,10 +188,11 @@ module EmailAddress
     # Customize your own error message text.
     def self.error_messages(hash = {}, locale = "en", *extra)
       hash = extra.first if extra.first.is_a? Hash
+
       @errors[locale] ||= {}
       @errors[locale]["email_address"] ||= {}
 
-      unless hash.empty?
+      unless hash.nil? || hash.empty?
         @errors[locale]["email_address"] = @errors[locale]["email_address"].merge(hash)
       end
 

--- a/lib/email_address/host.rb
+++ b/lib/email_address/host.rb
@@ -34,7 +34,7 @@ module EmailAddress
     attr_reader :host_name
     attr_accessor :dns_name, :domain_name, :registration_name,
       :tld, :tld2, :subdomains, :ip_address, :config, :provider,
-      :comment, :error_message, :reason
+      :comment, :error_message, :reason, :locale
     MAX_HOST_LENGTH = 255
 
     # Sometimes, you just need a Regexp...
@@ -84,8 +84,9 @@ module EmailAddress
 
     # host name -
     #   * host type - :email for an email host, :mx for exchanger host
-    def initialize(host_name, config = {})
+    def initialize(host_name, config = {}, locale = "en")
       @original = host_name ||= ""
+      @locale = locale
       config[:host_type] ||= :email
       @config = config.is_a?(Hash) ? Config.new(config) : config
       @error = @error_message = nil
@@ -497,7 +498,7 @@ module EmailAddress
     def set_error(err, reason = nil)
       @error = err
       @reason = reason
-      @error_message = Config.error_message(err)
+      @error_message = Config.error_message(err, locale)
       false
     end
 

--- a/lib/email_address/local.rb
+++ b/lib/email_address/local.rb
@@ -69,7 +69,7 @@ module EmailAddress
   class Local
     attr_reader   :local
     attr_accessor :mailbox, :comment, :tag, :config, :original
-    attr_accessor :syntax
+    attr_accessor :syntax, :locale
 
     # RFC-2142: MAILBOX NAMES FOR COMMON SERVICES, ROLES AND FUNCTIONS
     BUSINESS_MAILBOXES = %w(info marketing sales support)
@@ -106,10 +106,11 @@ module EmailAddress
     RELAXED_TAG_REGEX  = #  AZaz09_!#$%&'*+-/=?^`{|}~
       %r/^([\w\.\!\#\$\%\&\'\*\+\-\/\=\?\^\`\{\|\}\~]+)$/i.freeze
 
-    def initialize(local, config={}, host=nil)
+    def initialize(local, config={}, host=nil, locale="en")
       @config = config.is_a?(Hash) ? Config.new(config) : config
       self.local    = local
       @host         = host
+      @locale       = locale
       @error        = @error_message = nil
     end
 
@@ -388,7 +389,7 @@ module EmailAddress
     def set_error(err, reason=nil)
       @error = err
       @reason= reason
-      @error_message = Config.error_message(err)
+      @error_message = Config.error_message(err, locale)
       false
     end
 


### PR DESCRIPTION
Hi, this PR is similar to #67 but `I18n` is only used from `EmailAddress::ActiveRecordValidator`.  Translation strings can be provided as already documented on the README and I added an example initializer for Rails.