### PR TITLE
Support Ruby 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: ruby
 rvm:
-  - 2.7.0
-  - 2.3.0
-  - jruby-9.2.9.0
+  - 2.5
+  - 2.6
+  - 2.7
+  - 3.0
+  - jruby
 
 addons:
   code_climate:

--- a/email_address.gemspec
+++ b/email_address.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/afair/email_address"
   spec.license       = "MIT"
 
-  #spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.5", "< 4"
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency "activerecord", "=  4.2.10"
     spec.add_development_dependency "activerecord-jdbcsqlite3-adapter", '~> 1.3.24'
   else
-    spec.add_development_dependency "activerecord", "~> 5.2.4"
+    spec.add_development_dependency "activerecord", "~> 6.0"
     spec.add_development_dependency "sqlite3"
   end
   #spec.add_development_dependency "codeclimate-test-reporter"


### PR DESCRIPTION
1.  Specify `required_ruby_version`.
2.  Update `activerecord` development dependency from 5.2 to 6.0
    Rails 5 is still in maintenance, but has no and will no Ruby 3 support.
3.  Add Ruby 3 to CI, also remove patch versions.
4.  Increase required Ruby version from 2.3 to 2.5.
    Rails 6 requires at least 2.5, also 2.3 and 2.4 are no more
    even in security maintenance.
5.  Add CI runs for Ruby 2.6 and 2.7.

This PR resolves the error from #74, but we also will need to fix the phantom fail.