### PR TITLE
Fix undefined method for nil on error message in config

### DIFF
--- a/lib/email_address/config.rb
+++ b/lib/email_address/config.rb
@@ -188,7 +188,7 @@ module EmailAddress
     end
 
     def self.error_message(name, locale = "en")
-      @errors[locale]["email_address"][name.to_s] || name.to_s
+      @errors[locale]&.dig("email_address")&.dig(name.to_s) || name.to_s
     end
 
     # Customize your own error message text.

--- a/lib/email_address/config.rb
+++ b/lib/email_address/config.rb
@@ -188,7 +188,7 @@ module EmailAddress
     end
 
     def self.error_message(name, locale = "en")
-      @errors[locale]&.dig("email_address")&.dig(name.to_s) || name.to_s
+      @errors.dig(locale, "email_address", name.to_s) || name.to_s
     end
 
     # Customize your own error message text.


### PR DESCRIPTION
In the config method error_message sometimes I get an error:

undefined method `[]' for nil:NilClass

By switching to dig and with safe operators we can prevent the error from being triggered.