### PR TITLE
Check `host_local` when performing `host_validation: :syntax` check

### DIFF
--- a/lib/email_address/host.rb
+++ b/lib/email_address/host.rb
@@ -402,11 +402,7 @@ module EmailAddress
     # True if the host name has a DNS A Record
     def valid_dns?
       return true unless dns_enabled?
-      bool = dns_a_record.size > 0 || set_error(:domain_unknown)
-      if localhost? && !@config[:host_local]
-        bool = set_error(:domain_no_localhost)
-      end
-      bool
+      dns_a_record.size > 0 || set_error(:domain_unknown)
     end
 
     # True if the host name has valid MX servers configured in DNS
@@ -430,7 +426,9 @@ module EmailAddress
     # True if the host_name passes Regular Expression match and size limits.
     def valid_format?
       if host_name =~ CANONICAL_HOST_REGEX && to_s.size <= MAX_HOST_LENGTH
-        return true if localhost?
+        if localhost?
+          return @config[:host_local] ? true : set_error(:domain_no_localhost)
+        end
         return true if host_name.include?(".") # require FQDN
       end
       set_error(:domain_invalid)

--- a/test/email_address/test_address.rb
+++ b/test/email_address/test_address.rb
@@ -104,6 +104,8 @@ class TestAddress < Minitest::Test
     assert_equal EmailAddress.error("user1"), "Invalid Domain Name"
     assert_equal EmailAddress.error("user1", host_local: true), "This domain is not configured to accept email"
     assert_equal EmailAddress.error("user1@localhost", host_local: true), "This domain is not configured to accept email"
+    assert_equal EmailAddress.error("user1@localhost", host_local: false, host_validation: :syntax), "localhost is not allowed for your domain name"
+    assert_equal EmailAddress.error("user1@localhost", host_local: false, dns_lookup: :off), "localhost is not allowed for your domain name"
     assert_nil EmailAddress.error("user2@localhost", host_local: true, dns_lookup: :off, host_validation: :syntax)
   end
 


### PR DESCRIPTION
Hi!

Thank you for this marvelous gem! I learned a bunch just by reading the README.

While playing with the gem I stumbled upon this scenario. The result seems unusual:

    EmailAddress.valid?("john@localhost", host_validation: :syntax, host_local: false) # => true

The expectation was that the validation check will return `false` given that we're disallowing `localhost`.

This PR addresses the above scenario. I _think_ the implementation is clean. If not, please let me know and I'll make changes. Thanks