### PR TITLE
Allow to accept non-FQDN domains but reject local-only addresses

### DIFF
--- a/lib/email_address/config.rb
+++ b/lib/email_address/config.rb
@@ -81,6 +81,12 @@ module EmailAddress
   # * host_local:         false,
   #   Allow localhost, no domain, or local subdomains.
   #
+  # * host_fqdn:          true
+  #   Check if host name is FQDN
+  #
+  # * host_auto_append:   true
+  #   Append localhost if host is missing
+  #
   # * address_validation: :parts, :smtp, ->(address) { true }
   #   Address validation policy
   #   :parts              Validate local and host.
@@ -129,6 +135,8 @@ module EmailAddress
       host_allow_ip: false,
       host_remove_spaces: false,
       host_local: false,
+      host_fqdn: true,
+      host_auto_append: true,
 
       address_validation: :parts, # :parts, :smtp, Proc
       address_size: 3..254,

--- a/lib/email_address/host.rb
+++ b/lib/email_address/host.rb
@@ -183,7 +183,7 @@ module EmailAddress
     def fully_qualified_domain_name(host_part)
       dn = @config[:address_fqdn_domain]
       if !dn
-        if (host_part.nil? || host_part <= " ") && @config[:host_local]
+        if (host_part.nil? || host_part <= " ") && @config[:host_local] && @config[:host_auto_append]
           "localhost"
         else
           host_part
@@ -428,6 +428,8 @@ module EmailAddress
         if localhost?
           return @config[:host_local] ? true : set_error(:domain_no_localhost)
         end
+
+        return true if !@config[:host_fqdn]
         return true if host_name.include?(".") # require FQDN
       end
       set_error(:domain_invalid)

--- a/test/email_address/test_address.rb
+++ b/test/email_address/test_address.rb
@@ -103,6 +103,7 @@ class TestAddress < Minitest::Test
     assert_equal false, e.valid? # localhost not allowed by default
     assert_equal EmailAddress.error("user1"), "Invalid Domain Name"
     assert_equal EmailAddress.error("user1", host_local: true), "This domain is not configured to accept email"
+    assert_equal EmailAddress.error("user1", host_local: true, host_auto_append: false), "Invalid Domain Name"
     assert_equal EmailAddress.error("user1@localhost", host_local: true), "This domain is not configured to accept email"
     assert_equal EmailAddress.error("user1@localhost", host_local: false, host_validation: :syntax), "localhost is not allowed for your domain name"
     assert_equal EmailAddress.error("user1@localhost", host_local: false, dns_lookup: :off), "localhost is not allowed for your domain name"

--- a/test/email_address/test_host.rb
+++ b/test/email_address/test_host.rb
@@ -68,6 +68,21 @@ class TestHost < MiniTest::Test
     assert_equal true, h.valid?
   end
 
+  def test_localhost
+    h = EmailAddress::Host.new("localhost", host_local: true, host_validation: :syntax)
+    assert_equal true, h.valid?
+  end
+
+  def test_host_no_dot
+    h = EmailAddress::Host.new("local", host_validation: :syntax)
+    assert_equal false, h.valid?
+  end
+
+  def test_host_no_dot_enable_fqdn
+    h = EmailAddress::Host.new("local", host_fqdn: false, host_validation: :syntax)
+    assert_equal true, h.valid?
+  end
+
   def test_comment
     h = EmailAddress::Host.new("(oops)gmail.com")
     assert_equal "gmail.com", h.to_s


### PR DESCRIPTION
Hi @afair

I'd like to propose 2 changes:

1) optionally allow non-FQDN hosts to pass. E.g. `mailbox@local`

2) optionally do not add hostname for input that is missing it. Even if local mailboxes are allowed.

See commit for the implementation