### PR TITLE
Treats email addresses starting with a plus sign as valid

### DIFF
--- a/lib/email_address/local.rb
+++ b/lib/email_address/local.rb
@@ -158,6 +158,9 @@ module EmailAddress
 
     def parse_tag(raw)
       separator = @config[:tag_separator] ||= "+"
+
+      return raw if raw.start_with? separator
+
       raw.split(separator, 2)
     end
 

--- a/test/email_address/test_local.rb
+++ b/test/email_address/test_local.rb
@@ -109,4 +109,8 @@ class TestLocal < MiniTest::Test
   def test_relaxed_tag
     assert EmailAddress.valid? "foo+abc@example.com", host_validation: :syntax, local_format: :relaxed
   end
+
+  def test_phone_mailbox
+    assert EmailAddress::Local.new("+3701234", local_format: :standard).valid?
+  end
 end


### PR DESCRIPTION
This allows addresses starting with `+` to be treat as valid in `standard` format. For example phone number based emails like `+12345@fax.com`. `+` is a valid character in local part and there's no restrictions that email can't start with `+`.