### PR TITLE
Add Ruby 3.2 to the CI matrix.  Quote 3.0 and update checkout action version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.6, 2.7, 3.0, 3.1, jruby]
+        ruby-version: [2.6, 2.7, "3.0", 3.1, 3.2, jruby]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}


### PR DESCRIPTION
Quoting the 3.0 is required to avoid truncation.  An unquoted "3.0" is truncated to "3", causing it to load the latest Ruby 3 version - currently 3.2.2 - rather than the latest 3.0.x version.

Runs green on my fork.