### PR TITLE
change ActiveRecordValidator

### DIFF
--- a/lib/email_address/active_record_validator.rb
+++ b/lib/email_address/active_record_validator.rb
@@ -12,7 +12,11 @@ module EmailAddress
   # * field: email,
   # * fields: [:email1, :email2]
   #
+  # * code: custom error code (default: :invalid_address)
+  # * message: custom error message (default: "Invalid Email Address")
+  #
   # Default field: :email or :email_address (first found)
+  #
   #
   class ActiveRecordValidator < ActiveModel::Validator
     def initialize(options = {})
@@ -35,10 +39,11 @@ module EmailAddress
       return if r[f].nil?
       e = Address.new(r[f])
       unless e.valid?
+        error_code = @opt[:code] || :invalid_address
         error_message = @opt[:message] ||
           Config.error_message(:invalid_address, I18n.locale.to_s) ||
           "Invalid Email Address"
-        r.errors.add(f, error_message)
+        r.errors.add(f, error_code, message: error_message)
       end
     end
   end

--- a/test/activerecord/test_ar.rb
+++ b/test/activerecord/test_ar.rb
@@ -9,8 +9,18 @@ class TestAR < MiniTest::Test
       user = User.new(email: "Pat.Jones+ASDF#GMAIL.com")
       assert_equal false, user.valid?
       assert user.errors.messages[:email].first
+
       user = User.new(email: "Pat.Jones+ASDF@GMAIL.com")
       assert_equal true, user.valid?
+    end
+  end
+
+  def test_validation_error_message
+    if RUBY_PLATFORM != "java" # jruby
+      user = User.new(alternate_email: "Pat.Jones+ASDF#GMAIL.com")
+      assert_equal false, user.valid?
+      assert user.errors.messages[:alternate_email].first.include?("Check your email")
+      assert_equal :some_error_code, user.errors.details[:alternate_email].first[:error]
     end
   end
 

--- a/test/activerecord/user.rb
+++ b/test/activerecord/user.rb
@@ -48,10 +48,13 @@ class User < ApplicationRecord
   if defined?(ActiveRecord) && ::ActiveRecord::VERSION::MAJOR >= 5
     attribute :email, :email_address
     attribute :canonical_email, :canonical_email_address
+    attribute :alternate_email, :email_address
   end
 
   validates_with EmailAddress::ActiveRecordValidator,
     fields: %i[email canonical_email]
+  validates_with EmailAddress::ActiveRecordValidator,
+    field: :alternate_email, code: :some_error_code, message: "Check your email"
 
   def email=(email_address)
     self[:canonical_email] = email_address


### PR DESCRIPTION
- changed method to add error to the record by adding "error_code"

This small addition allows to get `errors.details` output in the form
```ruby
{ email: [{ error: :invalid_address }] }
```
instead of 
```ruby
{ email: [{ error: "Invalid Email Address" }] }
```
and keep `errors.messages` the same...