### PR TITLE
validate Active Record Store fields

### DIFF
--- a/test/activerecord/test_ar.rb
+++ b/test/activerecord/test_ar.rb
@@ -34,4 +34,14 @@ class TestAR < MiniTest::Test
       end
     end
   end
+
+  def test_store_accessor_valid_email
+    user = User.new(support_email: "test@gmail.com")
+    assert user.valid?
+  end
+
+  def test_store_accessor_invalid_email
+    user = User.new(support_email: "this_is_not_an_email")
+    assert_equal false, user.valid?
+  end
 end

--- a/test/activerecord/user.rb
+++ b/test/activerecord/user.rb
@@ -45,6 +45,8 @@ end
 ################################################################################
 
 class User < ApplicationRecord
+  store :settings, accessors: [ :support_email ], coder: JSON
+
   if defined?(ActiveRecord) && ::ActiveRecord::VERSION::MAJOR >= 5
     attribute :email, :email_address
     attribute :canonical_email, :canonical_email_address
@@ -52,7 +54,7 @@ class User < ApplicationRecord
   end
 
   validates_with EmailAddress::ActiveRecordValidator,
-    fields: %i[email canonical_email]
+    fields: %i[email canonical_email support_email]
   validates_with EmailAddress::ActiveRecordValidator,
     field: :alternate_email, code: :some_error_code, message: "Check your email"
 


### PR DESCRIPTION
Fixes the issue with the gem not validating Active Record Store attributes in an AR model, as described here:

https://github.com/afair/email_address/issues/99