### PR TITLE
Fixes #102

### DIFF
--- a/lib/email_address/host.rb
+++ b/lib/email_address/host.rb
@@ -36,7 +36,7 @@ module EmailAddress
     MAX_HOST_LENGTH = 255
 
     # Sometimes, you just need a Regexp...
-    DNS_HOST_REGEX = / [\p{L}\p{N}]+ (?: (?: -{1,2} | \.) [\p{L}\p{N}]+ )*/x
+    DNS_HOST_REGEX = / [\p{L}\p{N}]+ (?: (?: -{1,3} | \.) [\p{L}\p{N}]+ )*/x
 
     # The IPv4 and IPv6 were lifted from Resolv::IPv?::Regex and tweaked to not
     # \A...\z anchor at the edges.

--- a/test/email_address/test_host.rb
+++ b/test/email_address/test_host.rb
@@ -161,4 +161,9 @@ class TestHost < MiniTest::Test
     assert !EmailAddress::Host.new("zaboz.com").valid?
     assert EmailAddress::Host.new("zaboz.com", dns_lookup: :a).valid?
   end
+
+  # Issue #102 off---white.com should be valid 
+  def test_triple_dash_domain 
+    assert EmailAddress::Host.new("off---white.com").valid?
+  end
 end


### PR DESCRIPTION
Triple dashes in domain names are unorthodox, but allowed.  