### PR TITLE
Improve CONVENTIONAL_MAILBOX_REGEX for j.d.-doe

### DIFF
--- a/lib/email_address/local.rb
+++ b/lib/email_address/local.rb
@@ -82,8 +82,8 @@ module EmailAddress
     STANDARD_MAX_SIZE = 64
 
     # Conventional : word([.-+'_]word)*
-    CONVENTIONAL_MAILBOX_REGEX = /\A [\p{L}\p{N}_]+ (?: [.\-+'_] [\p{L}\p{N}_]+ )* \z/x
-    CONVENTIONAL_MAILBOX_WITHIN = /[\p{L}\p{N}_]+ (?: [.\-+'_] [\p{L}\p{N}_]+ )*/x
+    CONVENTIONAL_MAILBOX_REGEX = /\A [\p{L}\p{N}_]+ (?: [.\-+'_]+ [\p{L}\p{N}_]+ )* \z/x
+    CONVENTIONAL_MAILBOX_WITHIN = /[\p{L}\p{N}_]+ (?: [.\-+'_]+ [\p{L}\p{N}_]+ )*/x
 
     # Relaxed: same characters, relaxed order
     RELAXED_MAILBOX_WITHIN = /[\p{L}\p{N}_]+ (?: [.\-+'_]+ [\p{L}\p{N}_]+ )*/x

--- a/test/email_address/test_local.rb
+++ b/test/email_address/test_local.rb
@@ -51,7 +51,7 @@ class TestLocal < MiniTest::Test
   end
 
   def test_valid_conventional
-    %w[first.last first First+Tag o'brien].each do |local|
+    %w[first.last first First+Tag o'brien j.d.-doe].each do |local|
       assert EmailAddress::Local.new(local).conventional?, local
     end
   end


### PR DESCRIPTION
I fixed a bug in the email validation regex that was incorrectly rejecting valid email addresses like "j.d.-doe@example.com".

The problem was that the regex required an alphanumeric character after every single punctuation mark. So in "j.d.-doe", after the dot following "d", it expected a letter or number, but found a hyphen instead, causing validation to
   fail.

The fix was simple: I changed the regex from [.\-+'_] (exactly one punctuation character) to [.\-+'_]+ (one or more punctuation characters). This allows consecutive punctuation like ".-" while still requiring alphanumeric
  characters at the start, end, and between punctuation groups.

I also added "j.d.-doe" as a test case to prevent regression, and verified all tests still pass.

Fixes https://github.com/afair/email_address/issues/104