### PR TITLE
Fix email validation to prevent silent truncation with newline characters

### DIFF
--- a/lib/email_address/address.rb
+++ b/lib/email_address/address.rb
@@ -38,7 +38,7 @@ module EmailAddress
 
     # Given an email address, this returns an array of [local, host] parts
     def self.split_local_host(email)
-      if (lh = email.match(/(.+)@(.+)/))
+      if (lh = email.match(/\A(.+)@(.+)\z/))
         lh.to_a[1, 2]
       else
         [email, ""]

--- a/test/email_address/test_address.rb
+++ b/test/email_address/test_address.rb
@@ -151,4 +151,11 @@ class TestAddress < Minitest::Test
   def test_nonstandard_tag
     # assert EmailAddress.valid?("asdfas+-@icloud.com")
   end
+
+  def test_newline_characters
+    assert !EmailAddress.valid?("user@foo.com\nother@bar.com")
+    assert !EmailAddress.valid?("user@foo.com\r\nother@bar.com")
+    assert EmailAddress.valid?("\nuser@foo.com") # valid because strip processing removes \n
+    assert EmailAddress.valid?("user@foo.com\r\n") # valid because strip processing removes \n
+  end
 end


### PR DESCRIPTION
### Summary
Fixed a data integrity issue where email addresses containing newline characters (`\n`, `\r\n`) were incorrectly validated as `true` due to silent truncation in the `split_local_host` method.

### Problem
The original regex `/(.+)@(.+)/` would match only up to the first `\n` character, causing silent data loss:

```ruby
# Before fix
"user@foo.com\nother@bar.com" → Local: "user", Host: "foo.com" → Valid ❌
"a@example.com\nb@example.com" → Local: "a", Host: "example.com" → Valid ❌
```

This created a data integrity risk where invalid input appeared as valid email addresses.

### Solution
Changed the regex in `split_local_host` method to use anchors:

```ruby
# Before
if (lh = email.match(/(.+)@(.+)/))

# After  
if (lh = email.match(/\A(.+)@(.+)\z/))
```

The `\A` and `\z` anchors ensure the entire string must match the email pattern. If newline characters are present, the regex fails to match, and the method returns `[email, ""]`, causing validation to fail appropriately.

### Changes
- **Core fix**: Modified regex in `Address.split_local_host` method (1 line change)
- **Test coverage**: Added comprehensive test cases for newline character scenarios

### Test Cases Added
```ruby
def test_newline_characters
  assert !EmailAddress.valid?("user@foo.com\nother@bar.com") # LF truncation
  assert !EmailAddress.valid?("user@foo.com\r\nother@bar.com") # CRLF truncation  
  assert EmailAddress.valid?("\nuser@foo.com") # valid because strip processing removes \n
  assert EmailAddress.valid?("user@foo.com\r\n") # valid because strip processing removes \n
end
```

### Verification
**Before fix:**
```ruby
EmailAddress.valid?("user@foo.com\nother@bar.com") # => true ❌
```

**After fix:**
```ruby
EmailAddress.valid?("user@foo.com\nother@bar.com") # => false ✅
```

### Backward Compatibility
- ✅ All existing functionality preserved
- ✅ No breaking changes to valid email address handling
- ✅ Only affects invalid input that was previously incorrectly accepted

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

**Note**: This fix addresses a data integrity issue where malformed input was silently truncated and incorrectly validated. The change ensures that only complete, well-formed email addresses are accepted as valid.