### PR TITLE
Allow double quote empty

### DIFF
--- a/lib/email_address/config.rb
+++ b/lib/email_address/config.rb
@@ -123,9 +123,9 @@ module EmailAddress
       local_encoding: :ascii, # :ascii, :unicode,
       local_parse: nil, # nil, Proc
       local_format: :conventional, # :conventional, :relaxed, :redacted, :standard, Proc
-      local_size: 1..64,
+      local_size: 0..64,
       tag_separator: "+", # nil, character
-      mailbox_size: 1..64, # without tag
+      mailbox_size: 0..64, # without tag
       mailbox_canonical: nil, # nil,  Proc
       mailbox_validator: nil, # nil,  Proc
 

--- a/lib/email_address/local.rb
+++ b/lib/email_address/local.rb
@@ -93,9 +93,9 @@ module EmailAddress
     #   Quoted Token can also have: SPACE \" \\ ( ) , : ; < > @ [ \ ] .
     STANDARD_LOCAL_WITHIN = /
       (?: [\p{L}\p{N}!\#$%&'*+\-\/=?\^_`{|}~()]+
-        | " (?: \\[" \\] | [\x20-\x21\x23-\x2F\x3A-\x40\x5B\x5D-\x60\x7B-\x7E\p{L}\p{N}] )+ " )
+        | " (?: \\[" \\] | [\x20-\x21\x23-\x2F\x3A-\x40\x5B\x5D-\x60\x7B-\x7E\p{L}\p{N}] )* " )
       (?: \.  (?: [\p{L}\p{N}!\#$%&'*+\-\/=?\^_`{|}~()]+
-              | " (?: \\[" \\] | [\x20-\x21\x23-\x2F\x3A-\x40\x5B\x5D-\x60\x7B-\x7E\p{L}\p{N}] )+ " ) )* /x
+              | " (?: \\[" \\] | [\x20-\x21\x23-\x2F\x3A-\x40\x5B\x5D-\x60\x7B-\x7E\p{L}\p{N}] )* " ) )* /x
 
     STANDARD_LOCAL_REGEX = /\A #{STANDARD_LOCAL_WITHIN} \z/x
 

--- a/test/email_address/test_local.rb
+++ b/test/email_address/test_local.rb
@@ -11,6 +11,7 @@ class TestLocal < MiniTest::Test
       %{"(comment)very.unusual.@.unusual.com"},
       %(#!$%&'*+-/=?^_`{}|~),
       %(" "),
+      %(""),
       %{"very.(),:;<>[]\\".VERY.\\"very@\\ \\"very\\".unusual"},
       %{"()<>[]:,;@\\\"!#$%&'*+-/=?^_`{}| ~.a"},
       %(token." ".token),

--- a/test/email_address/test_local.rb
+++ b/test/email_address/test_local.rb
@@ -31,7 +31,8 @@ class TestLocal < MiniTest::Test
       %(john..doe),
       %( invalid),
       %(invalid ),
-      %(abc"defghi"xyz)
+      %(abc"defghi"xyz),
+      %()
     ].each do |local|
       assert_equal false, EmailAddress::Local.new(local, local_fix: false).standard?, local
     end


### PR DESCRIPTION
According to RFC, empty dobule-quoted string is allowed in local part. E.g. `""@example.com`. This PR adds support for this.

Non-quoted empty string is still not allowed as per RFC. `test_invalid_standard` is expanded to ensure this.