### PR TITLE
Do not process nil values during casting

### DIFF
--- a/lib/email_address/canonical_email_address_type.rb
+++ b/lib/email_address/canonical_email_address_type.rb
@@ -34,7 +34,7 @@ module EmailAddress
 
     # From user input, setter
     def cast(value)
-      super(Address.new(value).canonical)
+      super(value && Address.new(value).canonical)
     end
 
     # From a database value

--- a/lib/email_address/email_address_type.rb
+++ b/lib/email_address/email_address_type.rb
@@ -34,7 +34,7 @@ module EmailAddress
 
     # From user input, setter
     def cast(value)
-      super(Address.new(value).normal)
+      super(value && Address.new(value).normal)
     end
 
     # From a database value

--- a/test/activerecord/test_ar.rb
+++ b/test/activerecord/test_ar.rb
@@ -31,6 +31,10 @@ class TestAR < MiniTest::Test
         user = User.new(email: "Pat.Jones+ASDF@GMAIL.com")
         assert_equal "pat.jones+asdf@gmail.com", user.email
         assert_equal "patjones@gmail.com", user.canonical_email
+
+        user = User.new(email: nil)
+        assert_nil user.email
+        assert_nil user.canonical_email
       end
     end
   end


### PR DESCRIPTION
We discovered that trying to set `user.email_address = nil` will not work as intuitively expected if the attribute type is `EmailAddress::CanonicalEmailAddressType`, since `Address.new(nil).canonical == ""`:

`EmailAddressType` behaves correctly.

```irb
001> EmailAddress::CanonicalEmailAddressType.new.cast(nil)
=> ""
002> EmailAddress::EmailAddressType.new.cast(nil)
=> nil
```

If the developer wishes to allow a column to contain a `NULL` value, for some reason, then we should not prevent that, and we should adopt intuitive semantics.

These changes ensure we only perform the cast logic if the value is truthy - this is not a change for `EmailAddressType`, but the same change was made there to be consistent.